### PR TITLE
[#1337] Removed server_class and configuration_class attributes. Updated version...

### DIFF
--- a/chevah/compat/interfaces.py
+++ b/chevah/compat/interfaces.py
@@ -29,34 +29,35 @@ class IDaemon(Interface):
 
 
 class IProcess(Interface):
-    '''A process represent a running Chevah application.
+    """
+    A process represents a running Chevah application.
 
     It can include a service, a local administration server and other
     utilities that are required by the application.
 
-    The name is somehow misleading as the IProcees can trigger and contain
+    The name is somehow misleading as the IProcess can trigger and contain
     multiple OS processes or threads.
-    '''
-
-    server_class = Attribute('Class user for launching main server process.')
-    configuration_class = Attribute(
-        'Class user for configuring the process.')
+    """
 
     def start():
-        '''Start the process.'''
+        """
+        Start the process.
+        """
 
     def stop():
-        '''Stops the process.
+        """
+        Stops the process.
 
-        Stopping the process will end product exection.
-        '''
+        Stopping the process will end product execution.
+        """
 
     def configure(configuration_path, configuration_file):
-        '''Configure the process.
+        """
+        Configure the process.
 
-        `configuration_path` and `configuration_file` are mutualy exclusive
+        `configuration_path` and `configuration_file` are mutually exclusive
         parameters.
-        '''
+        """
 
 
 class IProcessCapabilities(Interface):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import Command, find_packages, setup
 import os
 import shutil
 
-VERSION = '0.7.4'
+VERSION = '0.7.5'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
## Problem description

The following attributes are no longer used, they need to be removed:
- `server_class`
- `configuration_class`
## Changes description

I've removed the attributes and fixed the typos in the docstrings.
## How to try and test the changes

reviewers @adiroiban 

Please review the code changes. Make sure that all the tests pass.
