### PR TITLE
[#2155] Fix getTestUser.

### DIFF
--- a/chevah/compat/nt_filesystem.py
+++ b/chevah/compat/nt_filesystem.py
@@ -228,10 +228,14 @@ class NTFilesystem(PosixFilesystemBase):
         try:
             yield
         except WindowsError, error:
+            encoded_filename = None
+            if error.filename:
+                encoded_filename = error.filename.encode('utf-8')
+
             raise OSError(
                 error.errno,
                 error.strerror.encode('utf-8'),
-                error.filename.encode('utf-8'),
+                encoded_filename,
                 )
         except pywintypes.error as error:
             path = self.getRealPathFromSegments(segments)

--- a/chevah/compat/testing.py
+++ b/chevah/compat/testing.py
@@ -94,8 +94,14 @@ class CompatManufacture(ChevahCommonsFactory):
     def getTestUser(self, name):
         """
         Return an existing test user instance for user with `name`.
+        Return `None` if user is undefined.
         """
-        return TEST_USERS[name]
+        try:
+            result = TEST_USERS[name]
+        except KeyError:
+            result = None
+
+        return result
 
     def makeTestUser(self, name=None, password=None, posix_home_path=None,
                      home_group=None

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,13 @@ Release notes for chevah.compat
 ===============================
 
 
+0.21.1 - 22/05/2014
+-------------------
+
+* getTestUser returns None if the user is not found (undefined),
+* Treat error.filename as an optional attribute of WindowsError.
+
+
 0.21.0 - 19/05/2014
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.21.0'
+VERSION = '0.21.1'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
## Problem

Domain mixins could not be defined as `domain` test user is defined only on domain client machines.
## Changes

Return `None` when test user is not defined instead of raising an exception,
`error.filename` is an optional attribute of `WindowsError`.
## How to test

reviewers @adiroiban 

Please check that the code changes make sense.
