### PR TITLE
[#2464] Use instance variables for daemon configuration.

### DIFF
--- a/chevah/compat/interfaces.py
+++ b/chevah/compat/interfaces.py
@@ -12,13 +12,13 @@ class IDaemon(Interface):
     To stop the daemon you must send the KILL signal.
     """
 
-    PRESERVE_STANDARD_STREAMS = Attribute(
+    preserve_standard_streams = Attribute(
         """
         True if standard streams (input, output, error) should be redirected
         to the new daemon process.
         """)
 
-    DETACH_PROCESS = Attribute('True if process should detach from console.')
+    detach_process = Attribute('True if process should detach from console.')
 
     def __init__(options):
         """

--- a/chevah/compat/tests/normal/test_unix_service.py
+++ b/chevah/compat/tests/normal/test_unix_service.py
@@ -4,6 +4,7 @@
 Tests for Unix Daemon.
 """
 import os
+import sys
 
 from chevah.compat.exceptions import CompatError
 
@@ -79,39 +80,55 @@ class TestDaemon(CompatTestCase):
 
         self.assertProvides(IDaemon, daemon)
         self.assertEqual(options, daemon.options)
-        self.assertIsFalse(daemon.PRESERVE_STANDARD_STREAMS)
-        self.assertIsTrue(daemon.DETACH_PROCESS)
+        self.assertIsFalse(daemon.preserve_standard_streams)
+        self.assertIsTrue(daemon.detach_process)
 
-    def test_launch_PRESERVE_STANDARD_STREAMS(self):
+    def test_launch_preserve_standard_streams(self):
         """
-        When PRESERVE_STANDARD_STREAMS is set, the new daemon will
+        When preserve_standard_streams is set, the new daemon will
         inherit the standard stream.
         """
         pid_path = self.getPIDPath()
         options = self.Bunch(pid=pid_path)
         daemon = DaemonImplementation(options=options)
-        daemon.PRESERVE_STANDARD_STREAMS = True
+        daemon.preserve_standard_streams = True
 
         daemon.launch()
 
-        self.assertIsNotNone(daemon._daemon_context.stdin)
-        self.assertIsNotNone(daemon._daemon_context.stdout)
-        self.assertIsNotNone(daemon._daemon_context.stderr)
+        self.assertIs(sys.stdin, daemon._daemon_context.stdin)
+        self.assertIs(sys.stdout, daemon._daemon_context.stdout)
+        self.assertIs(sys.stderr, daemon._daemon_context.stderr)
 
-    def test_launch_DETACH_PROCESS(self):
+    def test_launch_preserve_standard_streams_not_set(self):
         """
-        At launch, DETACH_PROCESS is copied to the internal DaemonContext
+        When preserve_standard_streams is not set, the new daemon will use
+        a dedicated set of standard streams.
+        """
+        pid_path = self.getPIDPath()
+        options = self.Bunch(pid=pid_path)
+        daemon = DaemonImplementation(options=options)
+        daemon.preserve_standard_streams = False
+
+        daemon.launch()
+
+        self.assertIsNone(daemon._daemon_context.stdin)
+        self.assertIsNone(daemon._daemon_context.stdout)
+        self.assertIsNone(daemon._daemon_context.stderr)
+
+    def test_launch_detach_process(self):
+        """
+        At launch, detach_process is copied to the internal DaemonContext
         instance.
         """
         pid_path = self.getPIDPath()
         options = self.Bunch(pid=pid_path)
         daemon = DaemonImplementation(options=options)
-        daemon.DETACH_PROCESS = object()
+        daemon.detach_process = object()
 
         daemon.launch()
 
         self.assertEqual(
-            daemon.DETACH_PROCESS,
+            daemon.detach_process,
             daemon._daemon_context.detach_process,
             )
 

--- a/chevah/compat/unix_service.py
+++ b/chevah/compat/unix_service.py
@@ -24,15 +24,14 @@ class Daemon(object):
 
     DaemonContext = daemon.DaemonContext
 
-    PRESERVE_STANDARD_STREAMS = False
-    DETACH_PROCESS = True
-
     def __init__(self, options):
         """
         See `IDaemon`.
         """
         self.options = options
         self._daemon_context = None
+        self.preserve_standard_streams = False
+        self.detach_process = True
 
     def _onStopSignal(self, signum, frame):
         """
@@ -47,7 +46,7 @@ class Daemon(object):
         stdin = None
         stdout = None
         stderr = None
-        if self.PRESERVE_STANDARD_STREAMS:
+        if self.preserve_standard_streams:
             stdin = sys.stdin
             stdout = sys.stdout
             stderr = sys.stderr
@@ -57,7 +56,7 @@ class Daemon(object):
             stdout=stdout,
             stderr=stderr,
             )
-        self._daemon_context.detach_process = self.DETACH_PROCESS
+        self._daemon_context.detach_process = self.detach_process
         self._daemon_context.signal_map = {
             signal.SIGINT: self._onStopSignal,
             signal.SIGTERM: self._onStopSignal,

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,13 @@ Release notes for chevah.compat
 ===============================
 
 
+0.25.0 - 04/10/2014
+-------------------
+
+* Update Unix daemon to use instance variables for detach_process and
+  preserve_standard_streams.
+
+
 0.24.0 - 04/10/2014
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.24.0'
+VERSION = '0.25.0'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
# Problem

Daemon object uses class variables for configuration
# Why we got into this

There was no review and I was writing stupid code :)

It was not really a problem since an application most of the time has a single daemon :)
# Changes

Change variables to instance variables.
# How to test

reviewers: @alibotean 

this is just to let you know about changes. the changes are used on the server side to support osx.

Thanks!
