### PR TITLE
[#2514] Delete read only files on Windows.

### DIFF
--- a/chevah/compat/tests/normal/test_filesystem.py
+++ b/chevah/compat/tests/normal/test_filesystem.py
@@ -191,6 +191,21 @@ class TestLocalFilesystem(CompatTestCase, FilesystemTestMixin):
         self.assertTrue(self.filesystem.exists(self.test_segments))
         self.assertFalse(self.filesystem.exists(link_segments))
 
+    @conditionals.onOSFamily('nt')
+    def test_deleteFile_read_only(self):
+        """
+        On Windows, it will delete the file even if it has the read only
+        attribute.
+        """
+        segments = mk.fs.createFileInTemp()
+        path = self.filesystem.getRealPathFromSegments(segments)
+        os.chmod(path, stat.S_IREAD)
+        self.assertTrue(self.filesystem.exists(segments))
+
+        self.filesystem.deleteFile(segments)
+
+        self.assertFalse(self.filesystem.exists(segments))
+
     def test_deleteFolder_file_non_recursive(self):
         """
         Raise an OS error when trying to delete a file using folder API.
@@ -875,6 +890,25 @@ class TestLocalFilesystem(CompatTestCase, FilesystemTestMixin):
         self.assertFalse(self.filesystem.exists(initial_segments))
         self.assertFalse(self.filesystem.exists(self.test_segments))
         self.filesystem._touch(initial_segments)
+
+        self.filesystem.rename(initial_segments, self.test_segments)
+
+        self.assertFalse(self.filesystem.exists(initial_segments))
+        self.assertTrue(self.filesystem.exists(self.test_segments))
+
+    @conditionals.onOSFamily('nt')
+    def test_rename_file_read_only(self):
+        """
+        On Windows, it will rename the file even if it has the read only
+        attribute.
+        """
+        _, initial_segments = mk.fs.makePathInTemp()
+        _, self.test_segments = mk.fs.makePathInTemp()
+        self.assertFalse(self.filesystem.exists(initial_segments))
+        self.assertFalse(self.filesystem.exists(self.test_segments))
+        self.filesystem._touch(initial_segments)
+        path = self.filesystem.getRealPathFromSegments(initial_segments)
+        os.chmod(path, stat.S_IREAD)
 
         self.filesystem.rename(initial_segments, self.test_segments)
 

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,12 @@ Release notes for chevah.compat
 ===============================
 
 
+0.25.2 - 13/11/2014
+-------------------
+
+* Fix deleteFile on Windows to delete files which are read-only.
+
+
 0.25.1 - 29/10/2014
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.25.1'
+VERSION = '0.25.2'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
# Problem

If a file is read only on Windows, it can not be removed.
# Changes

Update deleteFile to remove read-only attribute before deleting the file.
I have also created a test for renameFile ... just in case there are errors there.
# How to test

reviewers: @alibotean 

check that changes make sense.
I have released this version so that we can use it in server.

thanks!
