### PR TITLE
[#2625] Update paver for new AIX 5.3 and 7.1.

### DIFF
--- a/paver.sh
+++ b/paver.sh
@@ -67,7 +67,7 @@ ARCH='x86'
 # For non-LSB distros we use the oldest supported Linux distro. No guarantees
 # made... For details, please see the Linux bits in detect_os() below.
 OS_LINUX_LSB='ubuntu1204'
-OS_LINUX_NONLSB='ubuntu1204'
+OS_LINUX_NONLSB='rhel4'
 
 
 clean_build() {


### PR DESCRIPTION
## Problem?

No support for AIX 7.1 in `compat`.
## Solution?

Update `paver.sh` from brink.
## How to test?

Please review changes.
Check remote tests.

reviewer @adiroiban 
