### PR TITLE
[#2815] Fix handling of Unicode and with spaces arguments on Windows

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,9 @@ and Windows, see IOSUsers.
 
 Support for staring Unix daemon and installing and starting Windows services.
 
+Importing this module on Windows will populate the sys.argv with Unicode
+values.
+
 Unified interface for working with operating system file systems provides:
 
 * Unicode

--- a/chevah/compat/__init__.py
+++ b/chevah/compat/__init__.py
@@ -6,6 +6,7 @@ Code for portable functions.
 """
 from __future__ import with_statement
 import os
+import sys
 
 if os.name == 'posix':
     from chevah.compat.unix_users import (
@@ -36,6 +37,7 @@ elif os.name == 'nt':
         )
     from chevah.compat.nt_capabilities import NTProcessCapabilities
     from chevah.compat.nt_filesystem import NTFilesystem
+    from chevah.compat.nt_unicode_argv import get_unicode_argv()
 
     system_users = NTUsers()
     process_capabilities = NTProcessCapabilities()
@@ -44,10 +46,13 @@ elif os.name == 'nt':
     DefaultAvatar = NTDefaultAvatar
     SuperAvatar = NTSuperAvatar
 
+    # Path Unicode sys.argv on Windows.
+    sys.argv = get_unicode_argv()
+
 else:
     raise AssertionError('Operating system "%s" not supported.' % (os.name))
 
 from chevah.compat.posix_filesystem import FileAttributes
-FileAttributes  # Silence the linter.
+
 
 local_filesystem = LocalFilesystem(avatar=DefaultAvatar())

--- a/chevah/compat/__init__.py
+++ b/chevah/compat/__init__.py
@@ -37,7 +37,7 @@ elif os.name == 'nt':
         )
     from chevah.compat.nt_capabilities import NTProcessCapabilities
     from chevah.compat.nt_filesystem import NTFilesystem
-    from chevah.compat.nt_unicode_argv import get_unicode_argv()
+    from chevah.compat.nt_unicode_argv import get_unicode_argv
 
     system_users = NTUsers()
     process_capabilities = NTProcessCapabilities()

--- a/chevah/compat/__init__.py
+++ b/chevah/compat/__init__.py
@@ -53,6 +53,7 @@ else:
     raise AssertionError('Operating system "%s" not supported.' % (os.name))
 
 from chevah.compat.posix_filesystem import FileAttributes
-
+# Silence the linter
+FileAttributes
 
 local_filesystem = LocalFilesystem(avatar=DefaultAvatar())

--- a/chevah/compat/nt_unicode_argv.py
+++ b/chevah/compat/nt_unicode_argv.py
@@ -1,0 +1,38 @@
+"""
+See: http://code.activestate.com/recipes/572200/
+
+Usage: simply import this module into a script. sys.argv is changed to
+be a list of Unicode strings.
+"""
+import sys
+
+
+def get_unicode_argv():
+    """
+    Uses shell32.GetCommandLineArgvW to get sys.argv as a list of Unicode
+    strings.
+
+    Versions 2.x of Python don't support Unicode in sys.argv on
+    Windows, with the underlying Windows API instead replacing multi-byte
+    characters with '?'.
+    """
+    from ctypes import POINTER, byref, cdll, c_int, windll
+    from ctypes.wintypes import LPCWSTR, LPWSTR
+
+    GetCommandLineW = cdll.kernel32.GetCommandLineW
+    GetCommandLineW.argtypes = []
+    GetCommandLineW.restype = LPCWSTR
+
+    CommandLineToArgvW = windll.shell32.CommandLineToArgvW
+    CommandLineToArgvW.argtypes = [LPCWSTR, POINTER(c_int)]
+    CommandLineToArgvW.restype = POINTER(LPWSTR)
+
+    cmd = GetCommandLineW()
+    argc = c_int(0)
+    argv = CommandLineToArgvW(cmd, byref(argc))
+    if argc.value > 0:
+        # Remove Python executable and commands if present
+        start = argc.value - len(sys.argv)
+        return [argv[i] for i in xrange(start, argc.value)]
+    else:
+        return sys.argv

--- a/chevah/compat/tests/manual/__init__.py
+++ b/chevah/compat/tests/manual/__init__.py
@@ -1,0 +1,3 @@
+"""
+Manual tests.
+"""

--- a/chevah/compat/tests/manual/batch_argv.bat
+++ b/chevah/compat/tests/manual/batch_argv.bat
@@ -4,8 +4,6 @@
 :: updated.
 
 @ECHO OFF
-CHCP 65001 > nul
-SET PYTHONIOENCODING=utf-8
 
 SET python_exe=lib\python.exe
 if not exist %python_exe% (
@@ -14,8 +12,12 @@ if not exist %python_exe% (
     GOTO:EOF
 )
 
-ECHO "Call as file"
-IF "%1"=="" (%python_exe% ..\chevah\compat\tests\manual\print_argv.py) ELSE %python_exe% ..\chevah\compat\tests\manual\print_argv.py ^%*^
+ECHO -
+ECHO ----- As file -----
+ECHO -
+%python_exe% ..\chevah\compat\tests\manual\print_argv.py ^%*^
 
-ECHO "Call as module"
-IF "%1"=="" (%python_exe% -m chevah.compat.tests.manual.print_argv) ELSE %python_exe% -m chevah.compat.tests.manual.print_argv ^%*^
+ECHO -
+ECHO ----- As module -----
+ECHO -
+%python_exe% -m chevah.compat.tests.manual.print_argv ^%*^

--- a/chevah/compat/tests/manual/batch_argv.bat
+++ b/chevah/compat/tests/manual/batch_argv.bat
@@ -15,7 +15,7 @@ if not exist %python_exe% (
 )
 
 ECHO "Call as file"
-%python_exe% ..\chevah\compat\tests\manual\print_argv.py ^%*^
+IF "%1"=="" (%python_exe% ..\chevah\compat\tests\manual\print_argv.py) ELSE %python_exe% ..\chevah\compat\tests\manual\print_argv.py ^%*^
 
 ECHO "Call as module"
-%python_exe% -m chevah.compat.tests.manual.print_argv ^%*^
+IF "%1"=="" (%python_exe% -m chevah.compat.tests.manual.print_argv) ELSE %python_exe% -m chevah.compat.tests.manual.print_argv ^%*^

--- a/chevah/compat/tests/manual/batch_argv.bat
+++ b/chevah/compat/tests/manual/batch_argv.bat
@@ -1,0 +1,15 @@
+:: Batch command to test passing of Unicode arguments
+:: and arguments with spaces from a Windows batch file
+
+@ECHO OFF
+CHCP 65001 > nul
+SET PYTHONIOENCODING=utf-8
+
+CD %~dp0
+if not exist lib\python.exe (
+    ECHO This file must be called from the root build folder.
+    PAUSE
+    GOTO:EOF
+)
+
+lib\python.exe -m chevah.compat.tests.manual.print_argv ^%*^

--- a/chevah/compat/tests/manual/batch_argv.bat
+++ b/chevah/compat/tests/manual/batch_argv.bat
@@ -18,4 +18,4 @@ ECHO "Call as file"
 %python_exe% ..\chevah\compat\tests\manual\print_argv.py ^%*^
 
 ECHO "Call as module"
-%python_exe% -m chevah\compat\tests\manual\print_argv.py ^%*^
+%python_exe% -m chevah.compat.tests.manual.print_argv ^%*^

--- a/chevah/compat/tests/manual/batch_argv.bat
+++ b/chevah/compat/tests/manual/batch_argv.bat
@@ -5,11 +5,11 @@
 CHCP 65001 > nul
 SET PYTHONIOENCODING=utf-8
 
-CD %~dp0
-if not exist lib\python.exe (
-    ECHO This file must be called from the root build folder.
+SET python_exe=lib\python.exe
+if not exist %python_exe% (
+    ECHO This must be called from the root build folder.
     PAUSE
     GOTO:EOF
 )
 
-lib\python.exe -m chevah.compat.tests.manual.print_argv ^%*^
+%python_exe% -m chevah.compat.tests.manual.print_argv ^%*^

--- a/chevah/compat/tests/manual/batch_argv.bat
+++ b/chevah/compat/tests/manual/batch_argv.bat
@@ -12,4 +12,4 @@ if not exist %python_exe% (
     GOTO:EOF
 )
 
-%python_exe% -m chevah.compat.tests.manual.print_argv ^%*^
+%python_exe% ..\chevah\compat\tests\manual\print_argv.py ^%*^

--- a/chevah/compat/tests/manual/batch_argv.bat
+++ b/chevah/compat/tests/manual/batch_argv.bat
@@ -1,19 +1,21 @@
 :: Batch command to test passing of Unicode arguments
 :: and arguments with spaces from a Windows batch file
+:: Make sure you call build command before this so that build folder is
+:: updated.
 
 @ECHO OFF
 CHCP 65001 > nul
 SET PYTHONIOENCODING=utf-8
 
-SET python_exe=build-windows-x86\lib\python.exe
+SET python_exe=lib\python.exe
 if not exist %python_exe% (
-    ECHO This must be called from the repo root folder.
+    ECHO This must be called from the root build folder.
     PAUSE
     GOTO:EOF
 )
 
 ECHO "Call as file"
-%python_exe% chevah\compat\tests\manual\print_argv.py ^%*^
+%python_exe% ..\chevah\compat\tests\manual\print_argv.py ^%*^
 
 ECHO "Call as module"
-%python_exe% chevah\compat\tests\manual\print_argv.py ^%*^
+%python_exe% -m chevah\compat\tests\manual\print_argv.py ^%*^

--- a/chevah/compat/tests/manual/batch_argv.bat
+++ b/chevah/compat/tests/manual/batch_argv.bat
@@ -13,11 +13,11 @@ if not exist %python_exe% (
 )
 
 ECHO -
-ECHO ----- As file -----
+ECHO ----- As file with -----
 ECHO -
-%python_exe% ..\chevah\compat\tests\manual\print_argv.py ^%*^
+%python_exe% ..\chevah\compat\tests\manual\print_argv.py ^%*
 
-ECHO -
+echo -
 ECHO ----- As module -----
 ECHO -
-%python_exe% -m chevah.compat.tests.manual.print_argv ^%*^
+%python_exe% -m chevah.compat.tests.manual.print_argv ^%*

--- a/chevah/compat/tests/manual/batch_argv.bat
+++ b/chevah/compat/tests/manual/batch_argv.bat
@@ -5,11 +5,15 @@
 CHCP 65001 > nul
 SET PYTHONIOENCODING=utf-8
 
-SET python_exe=lib\python.exe
+SET python_exe=build-windows-x86\lib\python.exe
 if not exist %python_exe% (
-    ECHO This must be called from the root build folder.
+    ECHO This must be called from the repo root folder.
     PAUSE
     GOTO:EOF
 )
 
-%python_exe% ..\chevah\compat\tests\manual\print_argv.py ^%*^
+ECHO "Call as file"
+%python_exe% chevah\compat\tests\manual\print_argv.py ^%*^
+
+ECHO "Call as module"
+%python_exe% chevah\compat\tests\manual\print_argv.py ^%*^

--- a/chevah/compat/tests/manual/print_argv.py
+++ b/chevah/compat/tests/manual/print_argv.py
@@ -8,6 +8,15 @@ Like::
     python chevah/compat/tests/manual/print_argv.py ARG1 ARG2
 """
 import sys
-from chevah import compat
-
+print 'Before import (for module import is already called)'
 print sys.argv
+
+from chevah import compat
+print 'After import'
+print sys.argv
+
+from chevah.compat.nt_unicode_argv import get_unicode_argv
+print 'Call again'
+print get_unicode_argv()
+print 'And again'
+print get_unicode_argv()

--- a/chevah/compat/tests/manual/print_argv.py
+++ b/chevah/compat/tests/manual/print_argv.py
@@ -1,0 +1,13 @@
+"""
+Call this script either as a file or as a module to see that arguments are
+in Unicode.
+
+Like::
+
+    python -m chevah.compat.tests.manual.print_argv ARG1 ARG2
+    python chevah/compat/tests/manual/print_argv.py ARG1 ARG2
+"""
+import sys
+from chevah import compat
+
+print sys.argv

--- a/chevah/compat/tests/manual/print_argv.py
+++ b/chevah/compat/tests/manual/print_argv.py
@@ -25,5 +25,3 @@ if os.name == 'nt':
     from chevah.compat.nt_unicode_argv import get_unicode_argv
     print 'Call again'
     print get_unicode_argv()
-    print 'And again'
-    print get_unicode_argv()

--- a/chevah/compat/tests/manual/print_argv.py
+++ b/chevah/compat/tests/manual/print_argv.py
@@ -6,8 +6,12 @@ Like::
 
     python -m chevah.compat.tests.manual.print_argv ARG1 ARG2
     python chevah/compat/tests/manual/print_argv.py ARG1 ARG2
+
+Make sure you call build command before calling this so that build folder
+is updated.
 """
 import sys
+import os
 print 'Before import (for module import is already called)'
 print sys.argv
 
@@ -15,8 +19,9 @@ from chevah import compat
 print 'After import'
 print sys.argv
 
-from chevah.compat.nt_unicode_argv import get_unicode_argv
-print 'Call again'
-print get_unicode_argv()
-print 'And again'
-print get_unicode_argv()
+if os.name == 'nt':
+    from chevah.compat.nt_unicode_argv import get_unicode_argv
+    print 'Call again'
+    print get_unicode_argv()
+    print 'And again'
+    print get_unicode_argv()

--- a/chevah/compat/tests/manual/print_argv.py
+++ b/chevah/compat/tests/manual/print_argv.py
@@ -16,6 +16,8 @@ print 'Before import (for module import is already called)'
 print sys.argv
 
 from chevah import compat
+# Silence the linter
+compat
 print 'After import'
 print sys.argv
 

--- a/chevah/compat/tests/normal/helper_sys_argv.py
+++ b/chevah/compat/tests/normal/helper_sys_argv.py
@@ -5,4 +5,11 @@ import sys
 
 # We print all after the first argument as the first argument should be
 # ignored.
+# First list arguments before importing compat.
+sys.stdout.write(repr(sys.argv[1:]))
+
+# List after importing.
+from chevah import compat
+# Silence the linter.
+compat
 sys.stdout.write(repr(sys.argv[1:]))

--- a/chevah/compat/tests/normal/helper_sys_argv.py
+++ b/chevah/compat/tests/normal/helper_sys_argv.py
@@ -1,0 +1,8 @@
+"""
+Helper script called to check sys.argv values.
+"""
+import sys
+
+# We print all after the first argument as the first argument should be
+# ignored.
+sys.stdout.write(repr(sys.argv[1:]))

--- a/chevah/compat/tests/normal/test_nt_unicode_argv.py
+++ b/chevah/compat/tests/normal/test_nt_unicode_argv.py
@@ -7,19 +7,10 @@ import os
 import subprocess
 import sys
 
-from chevah.compat.testing import CompatTestCase, conditionals, mk
-
-if os.name == 'nt':
-    import win32service
-    from chevah.compat.nt_service import ChevahNTService
-    # Silence the linter.
-    ChevahNTService
-else:
-    # This is here to allow defining test classes.
-    ChevahNTService = object
+from chevah.compat.testing import CompatTestCase, conditionals
 
 
-#@conditionals.onOSFamily('nt')
+@conditionals.onOSFamily('nt')
 class TestUnicodeArguments(CompatTestCase):
     """
     Unit tests for get_unicode_argv.
@@ -53,7 +44,7 @@ class TestUnicodeArguments(CompatTestCase):
         """
         out, err = self.runWithArguments([])
         self.assertEqual('', err)
-        self.assertEqual('[]', out)
+        self.assertEqual('[][]', out)
 
     def test_unicode_arguments_with_spaces(self):
         """
@@ -62,19 +53,29 @@ class TestUnicodeArguments(CompatTestCase):
         name = u'mon\u20acy'
 
         out, err = self.runWithArguments([
-            name.encode('utf-8'),
+            name.encode(sys.getfilesystemencoding()),
             '--with=simple',
             '--with=some spaces',
             '--with="double qoutes"',
             "--with='simple quotes'"
             ])
         self.assertEqual('', err)
-        self.assertEqual(
+
+        before = (
             '['
-            '\'mon\\xe2\\x82\\xacy\', '
+            '\'mon\\x80y\', '
             '\'--with=simple\', '
             '\'--with=some spaces\', '
             '\'--with="double qoutes"\', '
             '"--with=\'simple quotes\'"'
-            ']',
-            out)
+            ']')
+        after = (
+            '['
+            'u\'mon\\u20acy\', '
+            'u\'--with=simple\', '
+            'u\'--with=some spaces\', '
+            'u\'--with="double qoutes"\', '
+            'u"--with=\'simple quotes\'"'
+            ']'
+            )
+        self.assertEqual(before + after, out)

--- a/chevah/compat/tests/normal/test_nt_unicode_argv.py
+++ b/chevah/compat/tests/normal/test_nt_unicode_argv.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2011 Adi Roiban.
+"""
+Unit tests for get_unicode_argv.
+"""
+from threading import Timer
+import os
+import subprocess
+import sys
+
+from chevah.compat.testing import CompatTestCase, conditionals, mk
+
+if os.name == 'nt':
+    import win32service
+    from chevah.compat.nt_service import ChevahNTService
+    # Silence the linter.
+    ChevahNTService
+else:
+    # This is here to allow defining test classes.
+    ChevahNTService = object
+
+
+#@conditionals.onOSFamily('nt')
+class TestUnicodeArguments(CompatTestCase):
+    """
+    Unit tests for get_unicode_argv.
+    """
+
+    def runWithArguments(self, arguments, timeout=10):
+        """
+        Execute test script with arguments.
+        """
+        test_file = os.path.join(
+            os.path.dirname(__file__), 'helper_sys_argv.py')
+        command = [sys.executable, test_file]
+        command.extend(arguments)
+        proc = subprocess.Popen(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            )
+        timer = Timer(timeout, lambda p: p.kill(), [proc])
+        timer.start()
+        stdout, stderr = proc.communicate()
+        timer.cancel()
+        timer.join(timeout=10)
+        if timer.isAlive():
+            raise AssertionError('Timeout thread is still alive.')
+        return stdout, stderr
+
+    def test_not_arguments(self):
+        """
+        No arguments result empty list.
+        """
+        out, err = self.runWithArguments([])
+        self.assertEqual('', err)
+        self.assertEqual('[]', out)
+
+    def test_unicode_arguments_with_spaces(self):
+        """
+        Unicode arguments are preserved together with their spaces.
+        """
+        name = u'mon\u20acy'
+
+        out, err = self.runWithArguments([
+            name.encode('utf-8'),
+            '--with=simple',
+            '--with=some spaces',
+            '--with="double qoutes"',
+            "--with='simple quotes'"
+            ])
+        self.assertEqual('', err)
+        self.assertEqual(
+            '['
+            '\'mon\\xe2\\x82\\xacy\', '
+            '\'--with=simple\', '
+            '\'--with=some spaces\', '
+            '\'--with="double qoutes"\', '
+            '"--with=\'simple quotes\'"'
+            ']',
+            out)

--- a/pavement.py
+++ b/pavement.py
@@ -109,13 +109,12 @@ test_super
 SETUP['product']['name'] = 'chevah-compat'
 SETUP['folders']['source'] = u'chevah/compat'
 SETUP['repository']['name'] = u'compat'
-SETUP['github']['repo'] = 'chevah/compat'
+SETUP['repository']['github'] = u'https://github.com/chevah/compat'
 SETUP['pocket-lint']['include_files'] = ['pavement.py', 'release-notes.rst']
 SETUP['pocket-lint']['include_folders'] = ['chevah/compat']
 SETUP['pocket-lint']['exclude_files'] = []
 SETUP['test']['package'] = 'chevah.compat.tests'
 SETUP['test']['elevated'] = 'elevated'
-SETUP['github']['url'] = 'https://github.com/chevah/compat'
 SETUP['buildbot']['server'] = 'build.chevah.com'
 SETUP['buildbot']['web_url'] = 'http://build.chevah.com:10088'
 SETUP['pypi']['index_url'] = 'http://pypi.chevah.com:10042/simple'

--- a/paver.conf
+++ b/paver.conf
@@ -1,7 +1,7 @@
 # We are in brink itself, so we don't have to install brink.
 # This is here since we use the same bootstrap script for all projects.
 # Once each project uses its own bootstrap script, we can get rid of this.
-BRINK_VERSION='0.52.0'
+BRINK_VERSION='0.54.4'
 PYTHON_VERSION='python2.7'
 BINARY_DIST_URI='http://binary.chevah.com/production'
 PIP_INDEX='http://pypi.chevah.com:10042'

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,12 @@ Release notes for chevah.compat
 ===============================
 
 
+0.29.0 - 17/04/2015
+-------------------
+
+* Populate sys.argv with Unicode values on Windows.
+
+
 0.28.1 - 11/03/2015
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.28.1'
+VERSION = '0.29.0'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
Problem
=======

We can not receive unicode arguments in Windows from command line.

From our batch file we can not receive arguments with spaces.

Changes
=======

Use Unicode windows API to parse arguments.

Python 2.7 API is broken  and I can not use it to automate this tests as it fails to execute external command with unicode arguments 

To fix
====

Passing arguments with spaces from batch file is not yet fixed.


How to test
=========

reviewers: @alibotean 

```
paver build
./build-windows-x86/lib/python -m chevah.compat.tests.manual.print_argv ARG or NO ARG
```

from a plain cmd.exe
```
cd build-window-x86
..\chevah\compat\tests\manual\batch_argv.bat ARG or NO ARG
```