### PR TITLE
[#2845] Fix userExists on Unix to read /etc/passwd as normal user.

### DIFF
--- a/chevah/compat/unix_users.py
+++ b/chevah/compat/unix_users.py
@@ -129,12 +129,11 @@ class UnixUsers(CompatUsers):
             return False
 
         username = username.encode('utf-8')
-        with self._executeAsAdministrator():
-            try:
-                pwd.getpwnam(username)
-            except KeyError:
-                return False
-            return True
+        try:
+            pwd.getpwnam(username)
+        except KeyError:
+            return False
+        return True
 
     def isUserInGroups(self, username, groups, token=None):
         '''Return true if `username` is a member of `groups`.'''

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,12 @@ Release notes for chevah.compat
 ===============================
 
 
+0.30.1 - 22/05/2015
+-------------------
+
+* Fix userExists on Unix to not read /etc/passwd as root.
+
+
 0.30.0 - 26/04/2015
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.30.0'
+VERSION = '0.30.1'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
Problem
=======

/etc/passwd can be read by anyone on Unix ... but compat read it as root


Changes
=======

Read file as service account.


How to test
=========

reviewers: @alibotean 

check that changes make sense.

thanks!