### PR TITLE
[#3044] Add node_id and comparison to IFileAttributes.

### DIFF
--- a/chevah/compat/interfaces.py
+++ b/chevah/compat/interfaces.py
@@ -578,9 +578,14 @@ class IFileAttributes(Interface):
     is_file = Attribute('True if member is a file.')
     is_folder = Attribute('True if member is a folder.')
     is_link = Attribute('True if member is a symbolic link.')
-    modified = Attribute('Timestamp at which content modified.')
+    modified = Attribute('Timestamp at which content was last modified.')
 
     mode = Attribute('Protection bits. Unix specific.')
     hardlinks = Attribute('Number of hard links.')
+
     uid = Attribute('User ID or owner as integer.')
-    gid = Attribute('Group ID of owner as integer.')
+    gid = Attribute('Group ID as integer.')
+
+    node_id = Attribute('ID inside the filesystem.')
+    owner = Attribute('Name of the owner of this path.')
+    group = Attribute('Name of the group to which this path is associated.')

--- a/chevah/compat/posix_filesystem.py
+++ b/chevah/compat/posix_filesystem.py
@@ -234,7 +234,7 @@ class PosixFilesystemBase(object):
         """
         See `ILocalFilesystem`.
         """
-        raise NotImplementedError()
+        raise NotImplementedError('deleteFolder not implemented.')
 
     def _rmtree(self, path):
         """
@@ -440,15 +440,6 @@ class PosixFilesystemBase(object):
 
         return name
 
-    def getStatus(self, segments):
-        """
-        See `ILocalFilesystem`.
-        """
-        path = self.getRealPathFromSegments(segments)
-        path_encoded = self.getEncodedPath(path)
-        with self._impersonateUser():
-            return os.stat(path_encoded)
-
     def getAttributes(self, segments):
         """
         See `ILocalFilesystem`.
@@ -479,6 +470,7 @@ class PosixFilesystemBase(object):
             hardlinks=stats.st_nlink,
             uid=stats.st_uid,
             gid=stats.st_gid,
+            node_id=stats.st_ino,
             )
 
     def setAttributes(self, segments, attributes):
@@ -690,8 +682,11 @@ class FileAttributes(object):
     def __init__(
             self, name, path, size=0,
             is_file=False, is_folder=False, is_link=False,
-            modified=False,
-            mode=0, hardlinks=1, uid=0, gid=0,
+            modified=0,
+            mode=0, hardlinks=1,
+            uid=None, gid=None,
+            owner=None, group=None,
+            node_id=None,
             ):
         self.name = name
         self.path = path
@@ -705,3 +700,18 @@ class FileAttributes(object):
         self.hardlinks = hardlinks
         self.uid = uid
         self.gid = gid
+        self.node_id = node_id
+        self.owner = owner
+        self.group = group
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, self.__class__) and
+            self.__dict__ == other.__dict__
+            )
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __repr__(self):
+        return u"%s:%s:%s" % (self.__class__, id(self), self.__dict__)

--- a/chevah/compat/unix_filesystem.py
+++ b/chevah/compat/unix_filesystem.py
@@ -199,3 +199,12 @@ class UnixFilesystem(PosixFilesystemBase):
                 return self._rmtree(path_encoded)
             else:
                 return os.rmdir(path_encoded)
+
+    def getStatus(self, segments):
+        """
+        See `ILocalFilesystem`.
+        """
+        path = self.getRealPathFromSegments(segments)
+        path_encoded = self.getEncodedPath(path)
+        with self._impersonateUser():
+            return os.stat(path_encoded)

--- a/pavement.py
+++ b/pavement.py
@@ -65,8 +65,8 @@ BUILD_PACKAGES = [
     'chevah-github-hooks-server==0.1.6',
     'smmap==0.8.2',
     'async==0.6.1',
-    'gitdb==0.5.4',
-    'gitpython==0.3.2.RC1',
+    'gitdb==0.6.4',
+    'gitpython==1.0.1',
     'pygithub==1.10.0',
     ]
 

--- a/paver.conf
+++ b/paver.conf
@@ -1,7 +1,7 @@
 # We are in brink itself, so we don't have to install brink.
 # This is here since we use the same bootstrap script for all projects.
 # Once each project uses its own bootstrap script, we can get rid of this.
-BRINK_VERSION='0.54.4'
+BRINK_VERSION='0.55.4'
 PYTHON_VERSION='python2.7'
 BINARY_DIST_URI='http://binary.chevah.com/production'
 PIP_INDEX='http://pypi.chevah.com:10042'

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,13 @@ Release notes for chevah.compat
 ===============================
 
 
+0.31.0 - 08/10/2015
+-------------------
+
+* Add node_id, owner and group to IFileAttributes.
+* Add comparison between IFileAttributes.
+
+
 0.30.1 - 22/05/2015
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.30.1'
+VERSION = '0.31.0'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
Scope
=====

This branch updated the IFileAttributes to include node_id , owner and group members.
It also updates the FileAttributes implementation to support comparisons.


Changes
=======

The node_id is already available under Unix/Linux and was extend for Windows.

uid and gid are ok for local filesystem nodes but for example remote FTP files don't have uid/gid but just owne / group names.

0.31.0 was already publish as it is required by chevah.server

How to test
========

reviewers: @alibotean 

check that changes make sense.

You can create a hard link on Windows and then when getting status for both paths you should see the same id

