### PR TITLE
[#3113] Update group impersonation for OSX

### DIFF
--- a/chevah/compat/tests/elevated/test_system_users.py
+++ b/chevah/compat/tests/elevated/test_system_users.py
@@ -370,10 +370,13 @@ class TestSystemUsers(SystemUsersTestCase):
             self.assertEqual(TEST_ACCOUNT_GROUP, impersonated_groupname)
             self.assertNotEqual(initial_uid, uid)
             self.assertNotEqual(initial_gid, gid)
+            self.assertNotEqual(initial_groups, impersonated_groups)
             if self.os_name != 'osx':
                 # On OSX newer than 10.5 get/set groups are useless.
-                self.assertItemsEqual(
-                    self.getGroupsIDForTestAccount(), impersonated_groups)
+                self.assertEqual(
+                    sorted(self.getGroupsIDForTestAccount()),
+                    sorted(impersonated_groups),
+                    )
 
         self.assertEqual(initial_uid, os.geteuid())
         self.assertEqual(initial_gid, os.getegid())

--- a/chevah/compat/tests/elevated/test_system_users.py
+++ b/chevah/compat/tests/elevated/test_system_users.py
@@ -371,7 +371,7 @@ class TestSystemUsers(SystemUsersTestCase):
             self.assertNotEqual(initial_uid, uid)
             self.assertNotEqual(initial_gid, gid)
             if self.os_name != 'osx':
-                # On OSX never than 10.5 get/set groups are useless.
+                # On OSX newer than 10.5 get/set groups are useless.
                 self.assertItemsEqual(
                     self.getGroupsIDForTestAccount(), impersonated_groups)
 

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,13 @@ Release notes for chevah.compat
 ===============================
 
 
+0.31.2 - 17/11/2015
+-------------------
+
+* Remove dependencies from setup.py as we have POSIX only deps which fail on
+  Windows.
+
+
 0.31.1 - 17/11/2015
 -------------------
 

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,13 @@ Release notes for chevah.compat
 ===============================
 
 
+0.31.1 - 17/11/2015
+-------------------
+
+* Refactor group impersonation to use initgroups() rather than
+  getgroups/setgroups.
+
+
 0.31.0 - 08/10/2015
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.31.0'
+VERSION = '0.31.1'
 
 
 class PublishCommand(Command):
@@ -34,6 +34,8 @@ if os.name == 'posix':
     dependencies.extend([
         'python-daemon==1.5.5',
         'pam==0.1.4.c3',
+        # AIX only ar archive utility.
+        'arpy==1.1.1.c2',
         ])
 
 distribution = setup(

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.31.1'
+VERSION = '0.31.2'
 
 
 class PublishCommand(Command):
@@ -24,19 +24,12 @@ class PublishCommand(Command):
         assert os.getcwd() == self.cwd, (
             'Must be in package root: %s' % self.cwd)
         self.run_command('sdist')
-        self.distribution.get_command_obj('sdist')
+        self.run_command('bdist_wheel')
+
         upload_command = self.distribution.get_command_obj('upload')
         upload_command.repository = u'chevah'
         self.run_command('upload')
 
-dependencies = ['zope.interface ==3.8.0', 'future']
-if os.name == 'posix':
-    dependencies.extend([
-        'python-daemon==1.5.5',
-        'pam==0.1.4.c3',
-        # AIX only ar archive utility.
-        'arpy==1.1.1.c2',
-        ])
 
 distribution = setup(
     name="chevah-compat",
@@ -58,5 +51,4 @@ distribution = setup(
     cmdclass={
         'publish': PublishCommand,
         },
-    install_requires=dependencies,
     )


### PR DESCRIPTION
Scope
=====

os.setgroups fails on OSX https://docs.python.org/2/library/os.html#os.getgroups


Why we got this
============

* in python 2.5 there was no os.initgroups
* we updated to python 2.7.10 and the python is no longer build for osx 10.4


Changes
=======

instead of custom get/set groups use the dedicated initgroups method.

How to test
=========

reviewers: @alibotean 

check that changes make sense