### PR TITLE
[#3132] Auth OS accounts only based on PAM on AIX.

### DIFF
--- a/chevah/compat/tests/normal/test_filesystem.py
+++ b/chevah/compat/tests/normal/test_filesystem.py
@@ -924,7 +924,7 @@ class TestLocalFilesystem(CompatTestCase, FilesystemTestMixin):
 
         self.assertTrue(mk.fs.exists(self.test_segments))
         attributes = mk.fs.getAttributes(self.test_segments)
-        self.assertAlmostEqual(now, attributes.modified, delta=1)
+        self.assertAlmostEqual(now, attributes.modified, delta=1.5)
 
     def test_copyFile_destination_no_parent(self):
         """

--- a/chevah/compat/unix_users.py
+++ b/chevah/compat/unix_users.py
@@ -217,6 +217,11 @@ class UnixUsers(CompatUsers):
         Return False if user was not found or password is wrong.
         Returns None if password is stored in shadow file.
         '''
+        from chevah.compat import process_capabilities
+        if process_capabilities.os_name == 'aix':
+            # AIX /etc/passwd auth is disabled for this release.
+            return None
+
         username = username.encode('utf-8')
         password = password.encode('utf-8')
         try:

--- a/pavement.py
+++ b/pavement.py
@@ -43,11 +43,12 @@ RUN_PACKAGES = [
 if os.name == 'posix':
     RUN_PACKAGES.extend([
         'python-daemon==1.5.5',
+        # This is required as any other version will try to also update pip.
+        'lockfile==0.9.1',
         'pam==0.1.4.c3',
+        # Required for loading PAM lib on AIX.
+        'arpy==1.1.1.c2',
         ])
-
-if sys.platform.startswith('aix'):
-    RUN_PACKAGES.append('arpy==1.1.1.c2')
 
 
 BUILD_PACKAGES = [
@@ -142,12 +143,7 @@ def deps_testing():
     print('Installing testing dependencies to %s...' % (pave.path.build))
     pave.pip(
         command='install',
-        arguments=RUN_PACKAGES,
-        silent=True,
-        )
-    pave.pip(
-        command='install',
-        arguments=TEST_PACKAGES,
+        arguments=RUN_PACKAGES + TEST_PACKAGES,
         silent=True,
         )
 

--- a/paver.conf
+++ b/paver.conf
@@ -1,9 +1,10 @@
 # We are in brink itself, so we don't have to install brink.
 # This is here since we use the same bootstrap script for all projects.
 # Once each project uses its own bootstrap script, we can get rid of this.
-BRINK_VERSION='0.55.4'
+BRINK_VERSION='0.55.9'
 PYTHON_VERSION='python2.7'
 BINARY_DIST_URI='http://binary.chevah.com/production'
+CLEAN_PYTHON_BINARY_DIST_CACHE='no'
 PIP_INDEX='http://pypi.chevah.com:10042'
 PAVER_VERSION='1.2.4'
 PIP_VERSION="1.4.1.c4"

--- a/paver.sh
+++ b/paver.sh
@@ -3,7 +3,7 @@
 # See LICENSE for details.
 #
 # Helper script for bootstraping the build system on Unix/Msys.
-# It will write the default values into 'DEFAULT_VALUES' file.
+# It will write the default values in the 'DEFAULT_VALUES' file.
 #
 # To use this script you will need to publish binary archive files for the
 # following components:
@@ -15,7 +15,7 @@
 # It will delegate the argument to the paver script, with the exception of
 # these commands:
 # * clean - remove everything, except cache
-# * detect_os - create DEFAULT_VALUES and exit
+# * detect_os - detect operating system, create the DEFAULT_VALUES file and exit
 # * get_python - download Python distribution in cache
 # * get_agent - download Rexx/Putty distribution in cache
 #
@@ -29,8 +29,6 @@ set -o pipefail
 COMMAND=${1-''}
 DEBUG=${DEBUG-0}
 
-# Load repo specific configuration.
-source paver.conf
 
 # Set default locale.
 # We use C (alias for POSIX) for having a basic default value and
@@ -57,13 +55,22 @@ CACHE_FOLDER="cache"
 PYTHON_BIN=""
 PYTHON_LIB=""
 LOCAL_PYTHON_BINARY_DIST=""
-CLEAN_PYTHON_BINARY_DIST_CACHE=""
 
 # Put default values and create them as global variables.
 OS='not-detected-yet'
 ARCH='x86'
-CC='gcc'
-CXX='g++'
+
+# Initialize default values from paver.conf
+PYTHON_VERSION='python2.7'
+BINARY_DIST_URI='http://chevah.com/binary'
+PIP_INDEX='http://chevah.com/pypi'
+PAVER_VERSION='1.2.1'
+PIP_VERSION="1.4.1.c4"
+SETUPTOOLS_VERSION="1.4.1"
+CLEAN_PYTHON_BINARY_DIST_CACHE=""
+
+# Load repo specific configuration.
+source paver.conf
 
 
 clean_build() {
@@ -160,8 +167,7 @@ update_path_variables() {
 
 
 write_default_values() {
-    echo ${BUILD_FOLDER} ${PYTHON_VERSION} ${OS} ${ARCH} ${CC} ${CXX} \
-        > DEFAULT_VALUES
+    echo ${BUILD_FOLDER} ${PYTHON_VERSION} ${OS} ${ARCH} > DEFAULT_VALUES
 }
 
 
@@ -192,6 +198,7 @@ pip() {
             --index-url=$PIP_INDEX/simple \
             --download-cache=${CACHE_FOLDER} \
             --find-links=file://${CACHE_FOLDER} \
+            --use-wheel \
             --upgrade
 
     exit_code=$?
@@ -275,6 +282,8 @@ copy_python() {
             echo "No ${pip_package}. Start downloading it..."
             get_binary_dist "$pip_package" "$PIP_INDEX/packages"
         fi
+        # Clean previous pip installation.
+        rm -rf ${PYTHON_LIB}/site-packages/pip
         cp -RL "${CACHE_FOLDER}/$pip_package/pip" ${PYTHON_LIB}/site-packages/
 
         if [ ! -d ${CACHE_FOLDER}/$setuptools_package ]; then
@@ -286,6 +295,8 @@ copy_python() {
         cp -RL "${CACHE_FOLDER}/$setuptools_package//setuptools.egg-info" \
             ${PYTHON_LIB}/site-packages/
         cp "${CACHE_FOLDER}/$setuptools_package/pkg_resources.py" \
+            ${PYTHON_LIB}/site-packages/
+        cp -RL "${CACHE_FOLDER}/$setuptools_package/_markerlib" \
             ${PYTHON_LIB}/site-packages/
         cp "${CACHE_FOLDER}/$setuptools_package/easy_install.py" \
             ${PYTHON_LIB}/site-package
@@ -315,14 +326,14 @@ install_dependencies(){
     exit_code=$?
     set -e
     if [ $exit_code -ne 0 ]; then
-        echo 'Failed to run the inital "paver deps" command.'
+        echo 'Failed to run the initial "paver deps" command.'
         exit 1
     fi
 }
 
 
 #
-# Chech that we have a pavement.py in the current dir.
+# Check that we have a pavement.py in the current dir.
 # otherwise it means we are out of the source folder and paver can not be
 # used there.
 #
@@ -402,10 +413,6 @@ detect_os() {
 
     elif [ "${OS}" = "sunos" ]; then
 
-        # By default, we use Sun's Studio compiler. Comment these two for GCC.
-        CC="cc"
-        CXX="CC"
-
         ARCH=$(isainfo -n)
         os_version_raw=$(uname -r | cut -d'.' -f2)
         check_os_version Solaris 10 "$os_version_raw" os_version_chevah
@@ -414,11 +421,6 @@ detect_os() {
 
     elif [ "${OS}" = "aix" ]; then
 
-        # By default, we use IBM's XL C compiler. Comment these two for GCC.
-        # Beware that GCC 4.2 from IBM's RPMs will fail with GMP and Python!
-        CC="xlc_r"
-        CXX="xlC_r"
-
         ARCH="ppc$(getconf HARDWARE_BITMODE)"
         os_version_raw=$(oslevel)
         check_os_version AIX 5.3 "$os_version_raw" os_version_chevah
@@ -426,8 +428,6 @@ detect_os() {
         OS="aix${os_version_chevah}"
 
     elif [ "${OS}" = "hp-ux" ]; then
-
-        # libffi and GMP do not compile with the HP compiler, so we use GCC.
 
         ARCH=$(uname -m)
         os_version_raw=$(uname -r | cut -d'.' -f2-)
@@ -441,8 +441,7 @@ detect_os() {
 
         if [ -f /etc/redhat-release ]; then
             # Avoid getting confused by Red Hat derivatives such as Fedora.
-            egrep 'Red\ Hat|CentOS|Scientific' /etc/redhat-release > /dev/null
-            if [ $? -eq 0 ]; then
+            if egrep -q 'Red\ Hat|CentOS|Scientific' /etc/redhat-release; then
                 os_version_raw=$(\
                     cat /etc/redhat-release | sed s/.*release// | cut -d' ' -f2)
                 check_os_version "Red Hat Enterprise Linux" 4 \
@@ -458,14 +457,25 @@ detect_os() {
                     "$os_version_raw" os_version_chevah
                 OS="sles${os_version_chevah}"
             fi
+        elif [ -f /etc/rpi-issue ]; then
+            # Raspbian is a special case, a Debian unofficial derivative.
+            if egrep -q ^'NAME="Raspbian GNU/Linux' /etc/os-release; then
+                os_version_raw=$(\
+                    grep ^'VERSION_ID=' /etc/os-release | cut -d'"' -f2)
+                check_os_version "Raspbian GNU/Linux" 7 \
+                    "$os_version_raw" os_version_chevah
+                # For now, we only generate a Raspbian version 7.x package,
+                # and we should use that in newer Raspbian versions too.
+                OS="raspbian7"
+            fi
         elif [ $(command -v lsb_release) ]; then
             lsb_release_id=$(lsb_release -is)
             os_version_raw=$(lsb_release -rs)
             if [ $lsb_release_id = Ubuntu ]; then
                 check_os_version "Ubuntu Long-term Support" 10.04 \
                     "$os_version_raw" os_version_chevah
-                # Only Long-term Support versions are oficially endorsed, thus
-                # $os_version_chevah should end in 04 and the first two digits
+                # Only Long-term Support versions are officially endorsed, thus
+                # $os_version_chevah should end in 04, and the first two digits
                 # should represent an even year.
                 if [ ${os_version_chevah%%04} != ${os_version_chevah} -a \
                     $(( ${os_version_chevah%%04} % 2 )) -eq 0 ]; then
@@ -478,10 +488,19 @@ detect_os() {
         ARCH=$(uname -m)
 
         os_version_raw=$(sw_vers -productVersion)
-        check_os_version "Mac OS X" 10.4 "$os_version_raw" os_version_chevah
+        check_os_version "Mac OS X" 10.8 "$os_version_raw" os_version_chevah
 
         # For now, no matter the actual OS X version returned, we use '108'.
         OS="osx108"
+
+    elif [ "${OS}" = "openbsd" ]; then
+        ARCH=$(uname -m)
+
+        os_version_raw=$(uname -r)
+        check_os_version "OpenBSD" 5.8 "$os_version_raw" os_version_chevah
+
+        # For now, no matter the actual OpenBSD version returned, we use '58'.
+        OS="openbsd58"
 
     else
         echo 'Unsupported operating system:' $OS
@@ -497,7 +516,7 @@ detect_os() {
         ARCH='sparc64'
     elif [ "$ARCH" = "ppc64" ]; then
         # Python has not been fully tested on AIX when compiled as a 64 bit
-        # application and has math rounding error problems (at least with XL C).
+        # binary, and has math rounding error problems (at least with XL C).
         ARCH='ppc'
     elif [ "$ARCH" = "aarch64" ]; then
         ARCH='arm64'

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,13 @@ Release notes for chevah.compat
 ===============================
 
 
+0.32.0 - 24/11/2015
+-------------------
+
+* Remove dependencies from setup.py as we have POSIX only deps which fail on
+  Windows.
+
+
 0.31.2 - 17/11/2015
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.31.2'
+VERSION = '0.32.0'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
Scope
=====

This is required for a specific sale to RoyalMail

They have an AIX system in which /etc/password is in conflict  with PAM.

This will disable /etc/passwd auth on AIX.

Change
=======

just disable for AIX

there is already a branch to add a separate PAM auth ... but we need more work to merge it

How to test
=========

reviewers: @alibotean 

check that changes make sense.

thanks