### PR TITLE
[#3370] Add support for FreeBSD.

### DIFF
--- a/chevah/compat/__init__.py
+++ b/chevah/compat/__init__.py
@@ -11,6 +11,27 @@ from __future__ import absolute_import
 import os
 import sys
 
+# Check stdblib shadow support.
+try:
+    import spwd
+    _HAS_SHADOW_SUPPORT = True
+except ImportError:
+    spwd = None
+    _HAS_SHADOW_SUPPORT = False
+
+# Check if OS is storing users in databases.
+try:
+    import dbm
+    import whichdb
+    db_type = whichdb.whichdb('/etc/pwd')
+    if db_type in ['dbm', 'bsddb185']:
+        _HAS_NDBM_SUPPORT = True
+    else:
+        _HAS_NDBM_SUPPORT = False
+except ImportError:
+    dbm = None
+    _HAS_NDBM_SUPPORT = False
+
 if os.name == 'posix':
     from chevah.compat.unix_users import (
         UnixDefaultAvatar,

--- a/chevah/compat/__init__.py
+++ b/chevah/compat/__init__.py
@@ -11,27 +11,6 @@ from __future__ import absolute_import
 import os
 import sys
 
-# Check stdblib shadow support.
-try:
-    import spwd
-    _HAS_SHADOW_SUPPORT = True
-except ImportError:
-    spwd = None
-    _HAS_SHADOW_SUPPORT = False
-
-# Check if OS is storing users in databases.
-try:
-    import dbm
-    import whichdb
-    db_type = whichdb.whichdb('/etc/pwd')
-    if db_type in ['dbm', 'bsddb185']:
-        _HAS_NDBM_SUPPORT = True
-    else:
-        _HAS_NDBM_SUPPORT = False
-except ImportError:
-    dbm = None
-    _HAS_NDBM_SUPPORT = False
-
 if os.name == 'posix':
     from chevah.compat.unix_users import (
         UnixDefaultAvatar,

--- a/chevah/compat/capabilities.py
+++ b/chevah/compat/capabilities.py
@@ -29,6 +29,8 @@ def _get_os_name():
         return 'hpux'
     elif family.startswith('openbsd'):
         return 'openbsd'
+    elif family.startswith('freebsd'):
+        return 'freebsd'
     else:
         raise AssertionError('OS "%s" not supported.' % family)
 

--- a/chevah/compat/testing/assertion.py
+++ b/chevah/compat/testing/assertion.py
@@ -272,12 +272,13 @@ class AssertionMixin(object):
             except StopIteration:
                 pass
             else:
-                message = u'Iterable is not empty.\n%s.' % (target,)
+                message = u'Iterable is not empty.\n%s.' % (
+                    repr(target).decode('utf-8'),)
                 raise AssertionError(message.encode('utf-8'))
             return
 
         if len(target) != 0:
-            message = u'Value is not empty.\n%s.' % (target)
+            message = u'Value is not empty.\n%s.' % (target,)
             raise AssertionError(message.encode('utf-8'))
 
     def assertIsNotEmpty(self, target):

--- a/chevah/compat/tests/elevated/test_system_users.py
+++ b/chevah/compat/tests/elevated/test_system_users.py
@@ -293,7 +293,7 @@ class TestSystemUsers(SystemUsersTestCase):
             password=TEST_ACCOUNT_PASSWORD,
             )
 
-        if self.os_name in ['aix', 'hpux', 'osx']:
+        if self.os_name in ['aix', 'hpux', 'osx', 'freebsd', 'openbsd']:
             # No shadow support.
             self.assertIsNone(result)
         else:

--- a/chevah/compat/tests/normal/test_filesystem.py
+++ b/chevah/compat/tests/normal/test_filesystem.py
@@ -969,8 +969,8 @@ class TestLocalFilesystem(CompatTestCase, FilesystemTestMixin):
         if self.os_name == 'aix':
             count = 3000
             base_timeout = 0.02
-        elif self.os_name == 'hpux':
-            # HP-UX does not allow more than 32765 members in a folder
+        elif self.os_name in ['hpux', 'freebsd', 'openbsd']:
+            # Some OS/FS does not allow more than 32765 members in a folder
             # and the slave is generally slow.
             count = 32000
             base_timeout = 0.1

--- a/chevah/compat/tests/normal/test_filesystem.py
+++ b/chevah/compat/tests/normal/test_filesystem.py
@@ -976,7 +976,7 @@ class TestLocalFilesystem(CompatTestCase, FilesystemTestMixin):
             base_timeout = 0.1
         else:
             count = 35000
-            base_timeout = 0.1
+            base_timeout = 0.2
 
         base_segments = self.folderInTemp()
 

--- a/chevah/compat/tests/normal/test_filesystem.py
+++ b/chevah/compat/tests/normal/test_filesystem.py
@@ -975,7 +975,7 @@ class TestLocalFilesystem(CompatTestCase, FilesystemTestMixin):
             count = 32000
             base_timeout = 0.1
         else:
-            count = 35000
+            count = 45000
             base_timeout = 0.2
 
         base_segments = self.folderInTemp()

--- a/chevah/compat/tests/normal/test_filesystem.py
+++ b/chevah/compat/tests/normal/test_filesystem.py
@@ -976,7 +976,7 @@ class TestLocalFilesystem(CompatTestCase, FilesystemTestMixin):
             base_timeout = 0.1
         else:
             count = 45000
-            base_timeout = 0.2
+            base_timeout = 0.1
 
         base_segments = self.folderInTemp()
 
@@ -995,6 +995,7 @@ class TestLocalFilesystem(CompatTestCase, FilesystemTestMixin):
 
         # Iterating at any step will not take long.
         result = []
+        result.append(next(iterator))
         try:
             while True:
                 with self.assertExecutionTime(base_timeout):

--- a/chevah/compat/tests/normal/test_system_users.py
+++ b/chevah/compat/tests/normal/test_system_users.py
@@ -104,7 +104,7 @@ class TestSystemUsers(CompatTestCase):
         # Windows don't support shadow.
         # FIXME:2717:
         # HP-UX shadow support is not enabled in our python build.
-        if self.os_name in ['aix', 'osx', 'windows', 'hpux']:
+        if self.os_name in ['aix', 'osx', 'windows', 'hpux', 'openbsd', 'freebsd']:
             raise self.skipTest()
 
         from chevah.compat.unix_users import HAS_SHADOW_SUPPORT

--- a/chevah/compat/tests/normal/test_system_users.py
+++ b/chevah/compat/tests/normal/test_system_users.py
@@ -104,7 +104,14 @@ class TestSystemUsers(CompatTestCase):
         # Windows don't support shadow.
         # FIXME:2717:
         # HP-UX shadow support is not enabled in our python build.
-        if self.os_name in ['aix', 'osx', 'windows', 'hpux', 'openbsd', 'freebsd']:
+        if self.os_name in [
+            'aix',
+            'freebsd',
+            'hpux',
+            'openbsd',
+            'osx',
+            'windows',
+                ]:
             raise self.skipTest()
 
         from chevah.compat.unix_users import HAS_SHADOW_SUPPORT

--- a/chevah/compat/tests/normal/testing/test_testcase.py
+++ b/chevah/compat/tests/normal/testing/test_testcase.py
@@ -561,7 +561,14 @@ class TestChevahTestCase(ChevahTestCase):
 
         This is a system test, but socket operations are light.
         """
-        if self.os_name in ['aix', 'solaris', 'osx', 'hpux']:
+        if self.os_name in [
+            'aix',
+            'freebsd',
+            'hpux',
+            'openbsd',
+            'osx',
+            'solaris',
+                ]:
             # On AIX and probably on other Unixes we can only bind on
             # existing fixed IP addressed like 127.0.0.1.
             raise self.skipTest()

--- a/chevah/compat/tests/normal/testing/test_testcase.py
+++ b/chevah/compat/tests/normal/testing/test_testcase.py
@@ -318,7 +318,6 @@ class TestTwistedTestCase(ChevahTestCase):
         def last_call():
             time.sleep(0.2)
             self.called = True
-            time.sleep(0.01)
 
         deferred = threads.deferToThread(last_call)
 

--- a/chevah/compat/unix_users.py
+++ b/chevah/compat/unix_users.py
@@ -20,6 +20,7 @@ try:
     HAS_SHADOW_SUPPORT = True
 except ImportError:
     HAS_SHADOW_SUPPORT = False
+    spwd = None
 
 from zope.interface import implements
 
@@ -315,35 +316,6 @@ class UnixUsers(CompatUsers):
             return None
         username = username.encode('utf-8')
         password = password.encode('utf-8')
-
-        def get_crypted_password(password, salt):
-            '''Return the crypted password based on salt.
-
-            salt can be an salted password.
-            '''
-            crypt_value = crypt.crypt(password, salt)
-            if os.sys.platform == 'sunos5' and crypt_value.startswith('$6$'):
-                # There is a bug in Python 2.5 and crypt add some extra
-                # values for shadow passwords of type 6.
-                crypt_value = crypt_value[:12] + crypt_value[20:]
-            return crypt_value
-
-        try:
-            with self._executeAsAdministrator():
-                crypted_password = spwd.getspnam(username).sp_pwd
-
-            # Locked account
-            if crypted_password in ('LK',):
-                return False
-
-            # Allow other methods to take over if password is not
-            # stored in shadow file.
-            if crypted_password in self._NOT_HERE:
-                return None
-        except KeyError:
-            return None
-
-        return _verifyCrypt(password, crypted_password)
 
     def _getPAMAuthenticate(self):
         """

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,13 @@ Release notes for chevah.compat
 ===============================
 
 
+0.43.0 - 04/05/2017
+-------------------
+
+* Fix assertIsNotEmpty with deep Unicode data.
+* Add minimal support for OpenBSD and FreeBSD.
+
+
 0.42.1 - 01/05/2017
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.42.1'
+VERSION = '0.43.0'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
Scope
=====

This adds support for freebsd... and also openbsd

Changes
=======

The *BSD support was added without shadow password.

I want to merge it now, as BSD is low prioirty and I don't think that we will add support for it soon... but we don't need to block on that and we can still use it without elevated support

as a drive by I have removed the get_crypted_password which is not used.

I have updated buildbot to run tests on openbsd and freebsd

How to test
=========

reviewers: @brunogola 

the coverate is bad as for now we don't run elevated tests on openbsd and freebsd due to lack of shadow password support

check that changes make sense... once this is master I will enable all buildslaves for compat