### PR TITLE
[#3416] Allow getting node id on Windows even when file is open.

### DIFF
--- a/chevah/compat/nt_filesystem.py
+++ b/chevah/compat/nt_filesystem.py
@@ -32,19 +32,35 @@ from chevah.compat.nt_users import NTDefaultAvatar, NTUsers
 from chevah.compat.posix_filesystem import PosixFilesystemBase
 
 
-# cut-and-pasted from MSDN
+#: https://msdn.microsoft.com/en-us/library/windows/desktop/aa364939.aspx
 # 0 Unknown
 # 1 No Root Directory
 # 2 Removable Disk
 # 3 Local Disk
 # 4 Network Drive
-# 5 Compact Disc
+# 5 Compact Disk
 # 6 RAM Disk
 LOCAL_DRIVE = 3
 
 # Not defined in win32api.
 # (0x400)
 FILE_ATTRIBUTE_REPARSE_POINT = 1024
+
+#: Win32 - File Access Rights Constants
+#: https://msdn.microsoft.com/en-us/library/windows/desktop/gg258116.aspx
+FILE_READ_ATTRIBUTES = 128
+
+#: Win32 - File Share Mode
+#: https://msdn.microsoft.com/en-us/library/windows/desktop/aa363858.aspx
+FILE_SHARE_PREVENT_OTHERS = 0
+
+#: Flags used for getStatus.
+#: https://github.com/python/cpython/blob/master/Modules/posixmodule.c#L1511
+FILE_STATUS_FLAGS = (
+    win32file.FILE_ATTRIBUTE_NORMAL |
+    win32file.FILE_FLAG_BACKUP_SEMANTICS |
+    win32file.FILE_FLAG_OPEN_REPARSE_POINT
+    )
 
 
 class NTFilesystem(PosixFilesystemBase):
@@ -337,11 +353,11 @@ class NTFilesystem(PosixFilesystemBase):
                 stats = os.stat(path_encoded)
             file_handle = win32file.CreateFileW(
                 path_encoded,
-                win32file.GENERIC_READ,
-                win32file.FILE_SHARE_READ,
+                FILE_READ_ATTRIBUTES,
+                FILE_SHARE_PREVENT_OTHERS,
                 None,
                 win32file.OPEN_EXISTING,
-                win32file.FILE_FLAG_BACKUP_SEMANTICS,
+                FILE_STATUS_FLAGS,
                 None,
                 )
 

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,13 @@ Release notes for chevah.compat
 ===============================
 
 
+0.35.0 - 17/05/2016
+-------------------
+
+* Fix getStatus on Windows to support files that are kept open by other
+  processes.
+
+
 0.34.0 - 18/10/2015
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.34.0'
+VERSION = '0.35.0'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
Scope
=====

Our `getStatus` implementation fails with an error for files that are kept open by other processes (or even our process).

We want to be able to get file information details even if the file is not closed yet.

Changes
=======

I've used the same flags as the ones in https://github.com/python/cpython/blob/master/Modules/posixmodule.c#L1499

Done a bit of TDD and added a functional test for this as well.

How to try and test the changes
===============================

reviewers: @adiroiban 

Please check that changes make sense. Once all is good I will add a test in the server which will break if we upgrade the compat without fixing the flow. At least this is my understanding that we want to do.
