### PR TITLE
[#3120] Compat: fix Python 2.7.4+ Windows path handling

### DIFF
--- a/chevah/compat/posix_filesystem.py
+++ b/chevah/compat/posix_filesystem.py
@@ -141,19 +141,22 @@ class PosixFilesystemBase(object):
         return self._pathSplitRecursive(path)
 
     def getPath(self, segments):
-        '''See `ILocalFilesystem`.'''
+        """
+        See `ILocalFilesystem`.
+        """
         if segments == []:
             return u'/'
-        else:
-            normalize_path = posixpath.normpath('/'.join(segments))
-            return u'/' + '/'.join(self._pathSplitRecursive(normalize_path))
+
+        normalized_path = posixpath.normpath(u'/'.join(segments))
+        return u'/' + u'/'.join(self._pathSplitRecursive(normalized_path))
 
     def getSegments(self, path):
-        '''See `ILocalFilesystem`.
+        """
+        See `ILocalFilesystem`.
 
         Get segment is the place where segments are created and we make sure
         they are in the internal encoding.
-        '''
+        """
         if path is None or path == '' or path == '.':
             return self.home_segments
 

--- a/chevah/compat/posix_filesystem.py
+++ b/chevah/compat/posix_filesystem.py
@@ -12,6 +12,7 @@ from contextlib import contextmanager
 import codecs
 import errno
 import os
+import posixpath
 import re
 import shutil
 import stat
@@ -144,7 +145,7 @@ class PosixFilesystemBase(object):
         if segments == []:
             return u'/'
         else:
-            normalize_path = os.path.normpath('/'.join(segments))
+            normalize_path = posixpath.normpath('/'.join(segments))
             return u'/' + '/'.join(self._pathSplitRecursive(normalize_path))
 
     def getSegments(self, path):
@@ -164,7 +165,7 @@ class PosixFilesystemBase(object):
             home_path = u'/' + u'/'.join(self.home_segments) + u'/'
             path = home_path + path
 
-        normalize_path = os.path.normpath(path)
+        normalize_path = posixpath.normpath(path)
         return self._pathSplitRecursive(normalize_path)
 
     @property

--- a/chevah/compat/tests/normal/test_filesystem.py
+++ b/chevah/compat/tests/normal/test_filesystem.py
@@ -1394,6 +1394,24 @@ class TestLocalFilesystemUnlocked(CompatTestCase, FilesystemTestMixin):
         segments = self.unlocked_filesystem.getSegments(u'/Aa/././bB')
         self.assertEqual([u'Aa', u'bB'], segments)
 
+        segments = self.unlocked_filesystem.getSegments(u'../a/b')
+        self.assertEqual([u'a', u'b'], segments)
+
+        segments = self.unlocked_filesystem.getSegments(u'/../a/b')
+        self.assertEqual([u'a', u'b'], segments)
+
+        segments = self.unlocked_filesystem.getSegments(u'//../a/b')
+        self.assertEqual([u'a', u'b'], segments)
+
+        segments = self.unlocked_filesystem.getSegments(u'./a/b')
+        self.assertEqual([u'a', u'b'], segments)
+
+        segments = self.unlocked_filesystem.getSegments(u'/./a/b')
+        self.assertEqual([u'a', u'b'], segments)
+
+        segments = self.unlocked_filesystem.getSegments(u'//./a/b')
+        self.assertEqual([u'a', u'b'], segments)
+
     def test_getRealPathFromSegments_unix(self):
         """
         Check getting real path for Unix.
@@ -1704,6 +1722,24 @@ class TestLocalFilesystemLocked(CompatTestCase):
 
         segments = self.locked_filesystem.getSegments(u'/././b')
         self.assertEqual([u'b'], segments)
+
+        segments = self.locked_filesystem.getSegments(u'../a/b')
+        self.assertEqual([u'a', u'b'], segments)
+
+        segments = self.locked_filesystem.getSegments(u'/../a/b')
+        self.assertEqual([u'a', u'b'], segments)
+
+        segments = self.locked_filesystem.getSegments(u'//../a/b')
+        self.assertEqual([u'a', u'b'], segments)
+
+        segments = self.locked_filesystem.getSegments(u'./a/b')
+        self.assertEqual([u'a', u'b'], segments)
+
+        segments = self.locked_filesystem.getSegments(u'/./a/b')
+        self.assertEqual([u'a', u'b'], segments)
+
+        segments = self.locked_filesystem.getSegments(u'//./a/b')
+        self.assertEqual([u'a', u'b'], segments)
 
         # Non unicode text will be converted to unicode
         segments = self.locked_filesystem.getSegments('/cAca')

--- a/chevah/compat/tests/normal/test_filesystem.py
+++ b/chevah/compat/tests/normal/test_filesystem.py
@@ -1449,7 +1449,7 @@ class TestLocalFilesystemUnlocked(CompatTestCase, FilesystemTestMixin):
         segments = self.unlocked_filesystem.getSegments(u'./Bubu')
         self.assertEqual(bubu_segments, segments)
 
-    def get_getSegments_deep_upper(self):
+    def test_getSegments_deep_upper(self):
         """
         Going deep in the root will block at root folder.
         """

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.35.0'
+VERSION = '0.35.1'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
Scope
=====

Paths that start with `//` are incorrectly handled on Windows.

Something changed starting with Python 2.7.4 release and the `ntpath.normpath` function which we are using is no longer removing the double slashes along with `.` and `..` from the beginning of the path.

This can translate into a security breach/issue for us.

There are several bugs that were fixed between 2.7.3 and 2.7.10 (current) that touch on `os.path.normpath` or `ntpath.normpath`.

Changes
=======

Since we are already using posix path separator internally for building paths I've replaced the calls to `os.path.normpath` with `posixpath.normpath`.

I've also extended the existing tests for getSegments to cover the issue.

How to try and test the changes
===============================

reviewers: @adiroiban 

Please check that changes make sense.