### PR TITLE
[#3646] Add API for writing with offset.

### DIFF
--- a/chevah/compat/interfaces.py
+++ b/chevah/compat/interfaces.py
@@ -471,11 +471,24 @@ class ILocalFilesystem(Interface):
     def openFileForWriting(segments, utf8=False):
         """
         Return a file object for writing into the file.
+
+        File is created if it does not exist.
+        File is truncated if it exists.
+        """
+
+    def openFileForUpdating(segments, utf8=False):
+        """
+        Return a file object for writing into the file.
+
+        File is not created if it does not exist.
+        File is not truncated if it exists.
         """
 
     def openFileForAppending(segments, utf8=False):
         """
         Return a file object for writing at the end a file.
+
+        File is created if it does not exists.
         """
 
     def getFileSize(segments):

--- a/chevah/compat/tests/normal/test_filesystem.py
+++ b/chevah/compat/tests/normal/test_filesystem.py
@@ -1379,7 +1379,7 @@ class TestLocalFilesystem(CompatTestCase, FilesystemTestMixin):
     def test_openFileForUpdating_non_existing(self):
         """
         An error is raised when trying to open a file which does not
-        exists for updating..
+        exists for updating.
         """
         path, segments = mk.fs.makePathInTemp()
 

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,13 @@ Release notes for chevah.compat
 ===============================
 
 
+0.36.0 - 13/11/2016
+-------------------
+
+* Add API for opening a file in write mode for updating. With seek enabled and
+  without truncation.
+
+
 0.35.0 - 17/05/2016
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.35.1'
+VERSION = '0.36.0'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
Scope
=====

chevah.compat does not allow opening a file in write mode and writing at arbitrary locations.

This is useful for allowing arbitrary write access.

This is needed for implementing REST command for FTP

Changes
=======

Add an openFileForUpdating API


How to try and test the changes
===============================

reviewers: @alibotean 

check that changes make sense

thanks!
