### PR TITLE
[#2234] Check for SeImpersonatePrivilege when reporting Windows capabilities.

### DIFF
--- a/chevah/compat/nt_capabilities.py
+++ b/chevah/compat/nt_capabilities.py
@@ -56,10 +56,12 @@ class NTProcessCapabilities(BaseProcessCapabilities):
     def impersonate_local_account(self):
         """
         See `IProcessCapabilities`.
-
-        On Windows we can always impersonate local accounts.
         """
-        return True
+        privileges = self.getCurrentPrivilegesDescription()
+        if ('SeImpersonatePrivilege' in privileges):
+            return True
+
+        return False
 
     @property
     def pam(self):

--- a/chevah/compat/testing.py
+++ b/chevah/compat/testing.py
@@ -410,17 +410,6 @@ class CompatTestCase(ChevahTestCase):
     For now, there is nothing special here.
     """
 
-    def runningAsAdministrator(self):
-        """
-        Return True if slave runs as administrator.
-        """
-        # Windows 2008 and DC client tests are done in administration mode,
-        # 2003 and XP under normal mode.
-        if 'win-2008' in self.hostname or 'win-dc' in self.hostname:
-            return True
-        else:
-            return False
-
     def assertCompatError(self, expected_id, actual_error):
         """
         Raise an error if `actual_error` is not a `CompatError` instance.

--- a/chevah/compat/tests/elevated/test_capabilities.py
+++ b/chevah/compat/tests/elevated/test_capabilities.py
@@ -56,17 +56,6 @@ class TestProcessCapabilities(FileSystemTestCase):
 
         self.assertTrue(result)
 
-    @conditionals.onOSFamily('nt')
-    @conditionals.onAdminPrivileges(False)
-    def test_get_home_folder_windows_regular(self):
-        """
-        Home folder cannot be retrieved when administrator privileges are
-        disabled (Windows 2003/Windows XP).
-        """
-        result = self.capabilities.get_home_folder
-
-        self.assertFalse(result)
-
     def test_getCurrentPrivilegesDescription(self):
         """
         Lists all available privileges and their state.

--- a/chevah/compat/tests/elevated/test_capabilities.py
+++ b/chevah/compat/tests/elevated/test_capabilities.py
@@ -36,24 +36,40 @@ class TestProcessCapabilities(FileSystemTestCase):
         result = self.capabilities.create_home_folder
         self.assertTrue(result)
 
-    def test_get_home_folder(self):
+    @conditionals.onOSFamily('posix')
+    def test_get_home_folder_posix(self):
         """
-        On unix we can always get home folder.
-
-        On Windows 7 and 2008 home folder path can be retrieved. On
-        all other system below Windows 7, the home folder can not be
-        retrieved yet.
+        On Unix we can always get home folder.
         """
         result = self.capabilities.get_home_folder
-        hostname = self.getHostname()
-        if 'win-xp' in hostname or 'win-2003' in hostname:
-            self.assertFalse(result)
-        else:
-            self.assertTrue(result)
+
+        self.assertTrue(result)
+
+    @conditionals.onOSFamily('nt')
+    @conditionals.onAdminPrivileges(True)
+    def test_get_home_folder_windows_admin(self):
+        """
+        Home folder can be retrieved when running with administrator
+        privileges.
+        """
+        result = self.capabilities.get_home_folder
+
+        self.assertTrue(result)
+
+    @conditionals.onOSFamily('nt')
+    @conditionals.onAdminPrivileges(False)
+    def test_get_home_folder_windows_regular(self):
+        """
+        Home folder cannot be retrieved when administrator privileges are
+        disabled (Windows 2003/Windows XP).
+        """
+        result = self.capabilities.get_home_folder
+
+        self.assertFalse(result)
 
     def test_getCurrentPrivilegesDescription(self):
         """
-        Check getCurrentPrivilegesDescription.
+        Lists all available privileges and their state.
         """
         text = self.capabilities.getCurrentPrivilegesDescription()
         if os.name == 'posix':

--- a/chevah/compat/tests/elevated/test_system_users.py
+++ b/chevah/compat/tests/elevated/test_system_users.py
@@ -423,9 +423,9 @@ class TestSystemUsers(SystemUsersTestCase):
             self.assertEqual(TEST_ACCOUNT_GROUP, impersonated_groupname)
             self.assertNotEqual(initial_uid, uid)
             self.assertNotEqual(initial_gid, gid)
-            # FIXME:3808:
-            # Investigate why this no longer works/passes on OSX.
             if self.os_name != 'osx':
+                # FIXME:3808:
+                # Investigate why this no longer works/passes on OSX.
                 self.assertNotEqual(initial_groups, impersonated_groups)
                 # On OSX newer than 10.5 get/set groups are useless.
                 self.assertEqual(

--- a/chevah/compat/tests/elevated/test_system_users.py
+++ b/chevah/compat/tests/elevated/test_system_users.py
@@ -423,8 +423,10 @@ class TestSystemUsers(SystemUsersTestCase):
             self.assertEqual(TEST_ACCOUNT_GROUP, impersonated_groupname)
             self.assertNotEqual(initial_uid, uid)
             self.assertNotEqual(initial_gid, gid)
-            self.assertNotEqual(initial_groups, impersonated_groups)
+            # FIXME:3808:
+            # Investigate why this no longer works/passes on OSX.
             if self.os_name != 'osx':
+                self.assertNotEqual(initial_groups, impersonated_groups)
                 # On OSX newer than 10.5 get/set groups are useless.
                 self.assertEqual(
                     sorted(self.getGroupsIDForTestAccount()),

--- a/chevah/compat/tests/normal/test_capabilities.py
+++ b/chevah/compat/tests/normal/test_capabilities.py
@@ -43,8 +43,17 @@ class TestProcessCapabilities(CompatTestCase):
         # 2003 and XP under normal mode.
         if 'win-2003' in self.hostname or 'win-xp' in self.hostname:
             return False
-        else:
-            return True
+
+        return True
+
+    def hasUAC(self):
+        """
+        Return True if Windows version has is UAC capable, False otherwise.
+        """
+        if 'win-2003' in self.hostname or 'win-xp' in self.hostname:
+            return False
+
+        return True
 
     def test_init(self):
         """
@@ -68,13 +77,16 @@ class TestProcessCapabilities(CompatTestCase):
         administration mode and disabled for the rest.
 
         See: runningAsAdministrator
+        See: hasUAC
         """
         result = self.capabilities.impersonate_local_account
 
         if self.runningAsAdministrator():
             self.assertTrue(result)
-        else:
+        elif self.hasUAC():
             self.assertFalse(result)
+        else:
+            self.assertTrue(result)
 
     def test_create_home_folder(self):
         """

--- a/chevah/compat/tests/normal/test_capabilities.py
+++ b/chevah/compat/tests/normal/test_capabilities.py
@@ -141,8 +141,11 @@ class TestNTProcessCapabilities(CompatTestCase):
         It raises an exception when an invalid privilege name is requested.
         """
         with self.assertRaises(AdjustPrivilegeException):
-            self.capabilities._elevatePrivileges(
-                win32security.SE_IMPERSONATE_NAME, 'no-such-privilege-name')
+            with (self.capabilities._elevatePrivileges(
+                    win32security.SE_IMPERSONATE_NAME,
+                    'no-such-privilege-name',
+                    )):
+                pass
 
     def test_get_home_folder(self):
         """

--- a/chevah/compat/tests/normal/test_capabilities.py
+++ b/chevah/compat/tests/normal/test_capabilities.py
@@ -20,6 +20,7 @@ from chevah.compat.interfaces import IProcessCapabilities
 from chevah.compat.testing import conditionals, CompatTestCase, mk
 
 
+@conditionals.onOSFamily('posix')
 class TestProcessCapabilitiesPosix(CompatTestCase):
     """
     Unit tests for process capabilities executed on Posix platforms.
@@ -27,9 +28,6 @@ class TestProcessCapabilitiesPosix(CompatTestCase):
 
     def setUp(self):
         super(TestProcessCapabilitiesPosix, self).setUp()
-
-        if self.os_family != 'posix':
-            raise self.skipTest('Only Posix platforms are supported')
 
         self.capabilities = process_capabilities
 
@@ -77,11 +75,6 @@ class TestProcessCapabilitiesPosix(CompatTestCase):
         """
         PAM is supported on Linux/Unix with the exception of HPUX.
         """
-        # FIXME:3813:
-        # Re-enable once we have a HP-UX buildslave.
-        # if self.os_name in ['hpux']:
-        #    self.assertFalse(self.capabilities.pam)
-
         self.assertTrue(self.capabilities.pam)
 
     def test_symbolic_link(self):
@@ -93,6 +86,7 @@ class TestProcessCapabilitiesPosix(CompatTestCase):
         self.assertTrue(symbolic_link)
 
 
+@conditionals.onOSFamily('nt')
 class TestNTProcessCapabilities(CompatTestCase):
     """
     Capability tests executed only on Windows slaves.
@@ -100,9 +94,6 @@ class TestNTProcessCapabilities(CompatTestCase):
 
     def setUp(self):
         super(TestNTProcessCapabilities, self).setUp()
-
-        if self.os_family != 'nt':
-            raise self.skipTest("Only Windows platforms supported.")
 
         self.capabilities = process_capabilities
 
@@ -159,6 +150,8 @@ class TestNTProcessCapabilities(CompatTestCase):
         self.assertFalse(self.capabilities.pam)
 
 
+@conditionals.onOSFamily('nt')
+@conditionals.onAdminPrivileges(False)
 class TestNTProcessCapabilitiesNormalUser(CompatTestCase):
     """
     Capability tests executed only on Windows slaves that are configured to
@@ -167,15 +160,6 @@ class TestNTProcessCapabilitiesNormalUser(CompatTestCase):
 
     def setUp(self):
         super(TestNTProcessCapabilitiesNormalUser, self).setUp()
-
-        if self.os_family != 'nt':
-            raise self.skipTest("Only Windows platforms supported.")
-
-        # Windows 2008 and DC client tests are done in administration mode,
-        # 2003 and XP under normal mode.
-        if 'win-2003' not in self.hostname and 'win-xp' not in self.hostname:
-            message = "Only Windows with normal rights supported"
-            raise self.skipTest(message)
 
         self.capabilities = process_capabilities
 
@@ -295,6 +279,8 @@ class TestNTProcessCapabilitiesNormalUser(CompatTestCase):
             self.assertNotContains('SeCreateGlobalPrivilege', text)
 
 
+@conditionals.onOSFamily('nt')
+@conditionals.onAdminPrivileges(True)
 class TestNTProcessCapabilitiesAdministrator(CompatTestCase):
     """
     Capability tests executed only on Windows slaves that are configured to
@@ -303,15 +289,6 @@ class TestNTProcessCapabilitiesAdministrator(CompatTestCase):
 
     def setUp(self):
         super(TestNTProcessCapabilitiesAdministrator, self).setUp()
-
-        if self.os_family != 'nt':
-            raise self.skipTest("Only Windows platforms supported.")
-
-        # Windows 2008 and DC client tests are done in administration mode,
-        # 2003 and XP under normal mode.
-        if 'win-2003' in self.hostname or 'win-xp' in self.hostname:
-            message = "Only Windows with administrator rights supported"
-            raise self.skipTest(message)
 
         self.capabilities = process_capabilities
 

--- a/chevah/compat/tests/normal/test_capabilities.py
+++ b/chevah/compat/tests/normal/test_capabilities.py
@@ -39,14 +39,12 @@ class TestProcessCapabilities(CompatTestCase):
         capabilities, but here we are testing the capabilities itself so is
         kind of chicken and egg problem.
         """
-        admin = False
-        try:
-            admin = os.getuid() == 0
-        except AttributeError:
-            import ctypes
-            admin = ctypes.windll.shell32.IsUserAnAdmin() != 0
-
-        return admin
+        # Windows 2008 and DC client tests are done in administration mode,
+        # 2003 and XP under normal mode.
+        if 'win-2003' in self.hostname or 'win-xp' in self.hostname:
+            return False
+        else:
+            return True
 
     def test_init(self):
         """

--- a/chevah/compat/tests/normal/test_capabilities.py
+++ b/chevah/compat/tests/normal/test_capabilities.py
@@ -145,6 +145,7 @@ class TestNTProcessCapabilities(CompatTestCase):
                     win32security.SE_IMPERSONATE_NAME,
                     'no-such-privilege-name',
                     )):
+                # pragma: no cover
                 pass
 
     def test_get_home_folder(self):

--- a/chevah/compat/tests/normal/test_capabilities.py
+++ b/chevah/compat/tests/normal/test_capabilities.py
@@ -64,8 +64,8 @@ class TestProcessCapabilities(CompatTestCase):
     @conditionals.onOSFamily('nt')
     def test_impersonate_local_account_windows(self):
         """
-        Impersonation is enabled on machines running the tests in administration
-        mode and disabled for the rest.
+        Impersonation is enabled on machines running the tests in
+        administration mode and disabled for the rest.
 
         See: runningAsAdministrator
         """

--- a/chevah/compat/tests/normal/test_capabilities.py
+++ b/chevah/compat/tests/normal/test_capabilities.py
@@ -64,10 +64,7 @@ class TestProcessCapabilities(CompatTestCase):
     @conditionals.onOSFamily('nt')
     def test_impersonate_local_account_windows(self):
         """
-        Impersonation is enabled on machines running the tests in
-        administration mode and disabled for the rest.
-
-        See: runningAsAdministrator
+        Impersonation is available on all our Windows machines.
         """
         result = self.capabilities.impersonate_local_account
 

--- a/chevah/compat/tests/normal/test_capabilities.py
+++ b/chevah/compat/tests/normal/test_capabilities.py
@@ -39,21 +39,14 @@ class TestProcessCapabilities(CompatTestCase):
         capabilities, but here we are testing the capabilities itself so is
         kind of chicken and egg problem.
         """
-        # Windows 2008 and DC client tests are done in administration mode,
-        # 2003 and XP under normal mode.
-        if 'win-2003' in self.hostname or 'win-xp' in self.hostname:
-            return False
+        admin = False
+        try:
+            admin = os.getuid() == 0
+        except AttributeError:
+            import ctypes
+            admin = ctypes.windll.shell32.IsUserAnAdmin() != 0
 
-        return True
-
-    def hasUAC(self):
-        """
-        Return True if Windows version has is UAC capable, False otherwise.
-        """
-        if 'win-2003' in self.hostname or 'win-xp' in self.hostname:
-            return False
-
-        return True
+        return admin
 
     def test_init(self):
         """
@@ -77,16 +70,10 @@ class TestProcessCapabilities(CompatTestCase):
         administration mode and disabled for the rest.
 
         See: runningAsAdministrator
-        See: hasUAC
         """
         result = self.capabilities.impersonate_local_account
 
-        if self.runningAsAdministrator():
-            self.assertTrue(result)
-        elif self.hasUAC():
-            self.assertFalse(result)
-        else:
-            self.assertTrue(result)
+        self.assertTrue(result)
 
     def test_create_home_folder(self):
         """

--- a/chevah/compat/tests/normal/test_capabilities.py
+++ b/chevah/compat/tests/normal/test_capabilities.py
@@ -64,9 +64,14 @@ class TestProcessCapabilities(CompatTestCase):
     @conditionals.onOSFamily('nt')
     def test_impersonate_local_account_windows(self):
         """
-        Impersonation is available on all our Windows machines.
+        Impersonation is available on all our Windows machines except Windows
+        2003.
         """
         result = self.capabilities.impersonate_local_account
+
+        # Windows 2003 BS is configured to execute with a non admin user.
+        if 'win-2003' in self.hostname:
+            self.assertFalse(result)
 
         self.assertTrue(result)
 

--- a/chevah/compat/tests/normal/test_capabilities.py
+++ b/chevah/compat/tests/normal/test_capabilities.py
@@ -133,8 +133,7 @@ class TestNTProcessCapabilities(CompatTestCase):
                     win32security.SE_IMPERSONATE_NAME,
                     'no-such-privilege-name',
                     )):
-                # pragma: no cover
-                pass
+                pass  # pragma: no cover
 
     def test_pam(self):
         """

--- a/chevah/compat/tests/normal/test_capabilities.py
+++ b/chevah/compat/tests/normal/test_capabilities.py
@@ -80,10 +80,12 @@ class TestProcessCapabilitiesPosix(CompatTestCase):
         """
         PAM is supported on Linux/Unix with the exception of HPUX.
         """
-        if self.os_name in ['hpux']:
-            self.assertFalse(self.capabilities.pam)
-        else:
-            self.assertTrue(self.capabilities.pam)
+        # FIXME:3813:
+        # Re-enable once we have a HP-UX buildslave.
+        # if self.os_name in ['hpux']:
+        #    self.assertFalse(self.capabilities.pam)
+
+        self.assertTrue(self.capabilities.pam)
 
     def test_symbolic_link(self):
         """
@@ -139,11 +141,8 @@ class TestNTProcessCapabilities(CompatTestCase):
         It raises an exception when an invalid privilege name is requested.
         """
         with self.assertRaises(AdjustPrivilegeException):
-            with (self.capabilities._elevatePrivileges(
-                    win32security.SE_IMPERSONATE_NAME,
-                    'no-such-privilege-name',
-                    )):
-                pass
+            self.capabilities._elevatePrivileges(
+                win32security.SE_IMPERSONATE_NAME, 'no-such-privilege-name')
 
     def test_get_home_folder(self):
         """

--- a/pavement.py
+++ b/pavement.py
@@ -164,7 +164,7 @@ def deps_testing():
     """
     Install dependencies for testing.
     """
-    print('Installing testing dependencies to %s...' % (pave.path.build))
+    print('Installing testing dependencies to %s...' % (pave.path.build,))
     pave.pip(
         command='install',
         arguments=RUN_PACKAGES + TEST_PACKAGES,
@@ -178,7 +178,7 @@ def deps_build():
     """
     Install dependencies for build environment.
     """
-    print('Installing build dependencies to %s...' % (pave.path.build))
+    print('Installing build dependencies to %s...' % (pave.path.build,))
     pave.pip(
         command='install',
         arguments=BUILD_PACKAGES,

--- a/pavement.py
+++ b/pavement.py
@@ -152,7 +152,6 @@ def update_setup():
 
 
 @task
-@needs('deps_testing', 'deps_build')
 def deps():
     """
     Install all dependencies.

--- a/pavement.py
+++ b/pavement.py
@@ -160,7 +160,6 @@ def deps():
     pave.pip(
         command='install',
         arguments=RUN_PACKAGES + TEST_PACKAGES + BUILD_PACKAGES,
-        silent=False,
         )
 
 

--- a/pavement.py
+++ b/pavement.py
@@ -157,32 +157,11 @@ def deps():
     """
     Install all dependencies.
     """
-
-
-@task
-def deps_testing():
-    """
-    Install dependencies for testing.
-    """
-    print('Installing testing dependencies to %s...' % (pave.path.build,))
+    print('Installing dependencies to %s...' % (pave.path.build,))
     pave.pip(
         command='install',
-        arguments=RUN_PACKAGES + TEST_PACKAGES,
-        silent=True,
-        )
-
-
-@task
-@needs('deps_testing')
-def deps_build():
-    """
-    Install dependencies for build environment.
-    """
-    print('Installing build dependencies to %s...' % (pave.path.build,))
-    pave.pip(
-        command='install',
-        arguments=BUILD_PACKAGES,
-        silent=True,
+        arguments=RUN_PACKAGES + TEST_PACKAGES + BUILD_PACKAGES,
+        silent=False,
         )
 
 

--- a/paver.conf
+++ b/paver.conf
@@ -1,4 +1,4 @@
-BRINK_VERSION='0.55.24'
+BRINK_VERSION='0.55.25'
 PYTHON_VERSION='python2.7'
 BINARY_DIST_URI='http://binary.chevah.com/production'
 PIP_INDEX='http://pypi.chevah.com'

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,13 @@ Release notes for chevah.compat
 ===============================
 
 
+0.36.1 - 02/12/2016
+-------------------
+
+* Impersonating local accounts is determined by the availability of
+  SeImpersonatePrivilege on Windows.
+
+
 0.36.0 - 13/11/2016
 -------------------
 

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,13 @@ Release notes for chevah.compat
 ===============================
 
 
+0.39.0 - 27/01/2017
+-------------------
+
+* Impersonating local accounts is determined by the availability of
+  SeImpersonatePrivilege on Windows.
+
+
 0.38.0 - 24/01/2017
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.38.0'
+VERSION = '0.39.0'
 
 
 class PublishCommand(Command):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.36.0'
+VERSION = '0.36.1'
 
 
 class PublishCommand(Command):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.36.1'
+VERSION = '0.37.0'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
Scope
=====

When running SFTPPlus in debug without administrator privileges it's unable to authenticate OS accounts.

The reason for this is that without `SeImpersonatePrivilege` we cannot impersonate the user and access it's home folder.

For legacy reasons on Windows we were reporting this availability as always available.

Changes
=======

Fixed the code to check for the specified privilege when reporting local account impersonation capability.

How to try and test the changes
===============================

reviewers: @adiroiban 

Please check that changes make sense. Once this is in I will fix the documentation on the server to describe this scenario and what should be done.
