### PR TITLE
[#3816] Add conditional for machine using administrator privileges when running tests.

### DIFF
--- a/chevah/compat/tests/normal/test_capabilities.py
+++ b/chevah/compat/tests/normal/test_capabilities.py
@@ -18,7 +18,7 @@ from zope.interface.verify import verifyObject
 from chevah.compat import process_capabilities
 from chevah.compat.exceptions import AdjustPrivilegeException
 from chevah.compat.interfaces import IProcessCapabilities
-from chevah.compat.testing import CompatTestCase, mk
+from chevah.compat.testing import conditionals, CompatTestCase, mk
 
 
 class TestProcessCapabilities(CompatTestCase):
@@ -122,6 +122,7 @@ class TestProcessCapabilities(CompatTestCase):
             self.assertTrue(self.capabilities.pam)
 
 
+@conditionals.onAdminPrivileges(True)
 class TestNTProcessCapabilities(TestProcessCapabilities):
     """
     Capability tests executed only on Windows.

--- a/chevah/compat/tests/normal/test_capabilities.py
+++ b/chevah/compat/tests/normal/test_capabilities.py
@@ -61,6 +61,7 @@ class TestProcessCapabilities(CompatTestCase):
         else:
             raise AssertionError('Unsupported os.')
 
+    @conditionals.onAdminPrivileges(True)
     def test_create_home_folder(self):
         """
         When running under normal account, we can not create home folders
@@ -91,6 +92,7 @@ class TestProcessCapabilities(CompatTestCase):
         else:
             raise AssertionError('Unsupported os.')
 
+    @conditionals.onAdminPrivileges(True)
     def test_getCurrentPrivilegesDescription(self):
         """
         Check getCurrentPrivilegesDescription.

--- a/chevah/compat/tests/normal/testing/test_mockup.py
+++ b/chevah/compat/tests/normal/testing/test_mockup.py
@@ -247,7 +247,7 @@ class TestHTTPServerContext(EmpiricalTestCase):
             response_content='first-content-of-different-length'
             )
         with HTTPServerContext([response]) as self.httpd:
-            response.updateReponseContent('updated-content')
+            response.updateResponseContent('updated-content')
 
             result = self.getPage('/url', persistent=False)
 

--- a/chevah/compat/tests/normal/testing/test_mockup.py
+++ b/chevah/compat/tests/normal/testing/test_mockup.py
@@ -307,6 +307,8 @@ class TestFactory(EmpiricalTestCase):
         """
         value = mk.bytes()
 
+        self.assertEqual(len(value), 8)
+
         with self.assertRaises(UnicodeDecodeError) as context:
             value.decode()
 
@@ -331,6 +333,8 @@ class TestFactory(EmpiricalTestCase):
         arbitrary size.
         """
         value = mk.bytes(8)
+
+        self.assertEqual(len(value), 8)
 
         with self.assertRaises(UnicodeDecodeError) as context:
             value.decode()
@@ -365,6 +369,8 @@ class TestFactory(EmpiricalTestCase):
         """
         value = mk.bytes(16)
 
+        self.assertEqual(len(value), 16)
+
         value.decode(encoding='utf-16')
 
     def test_bytes_string_conversion_utf16_invalid(self):
@@ -373,6 +379,8 @@ class TestFactory(EmpiricalTestCase):
         is used.
         """
         value = mk.bytes(size=15)
+
+        self.assertEqual(len(value), 15)
 
         with self.assertRaises(UnicodeDecodeError) as context:
             value.decode(encoding='utf-16')

--- a/chevah/compat/tests/normal/testing/test_mockup.py
+++ b/chevah/compat/tests/normal/testing/test_mockup.py
@@ -301,26 +301,84 @@ class TestFactory(EmpiricalTestCase):
         self.assertNotEqual(mk.bytes(), mk.bytes())
         self.assertIsInstance(bytearray, mk.bytes())
 
-    def test_bytes_string_conversion(self):
+    def test_bytes_string_conversion_utf8_default(self):
         """
-        Conversion to unicode will fail for ASCII/UTF-8/UTF-16.
+        Conversion to unicode will fail for ASCII/UTF-8 for the default size.
         """
-        value = mk.bytes(size=32)
+        value = mk.bytes()
 
-        with self.assertRaises(UnicodeDecodeError):
+        with self.assertRaises(UnicodeDecodeError) as context:
             value.decode()
 
-        with self.assertRaises(UnicodeDecodeError):
+        self.assertEndsWith(
+            context.exception.reason, 'ordinal not in range(128)')
+
+        with self.assertRaises(UnicodeDecodeError) as context:
             value.decode(encoding='ascii')
 
-        with self.assertRaises(UnicodeDecodeError):
+        self.assertEndsWith(
+            context.exception.reason, 'ordinal not in range(128)')
+
+        with self.assertRaises(UnicodeDecodeError) as context:
             value.decode(encoding='utf-8')
 
-        if self.os_name != 'aix':
-            # FIXME:3816:
-            # Fix this on AIX.
-            with self.assertRaises(UnicodeDecodeError):
-                value.decode(encoding='utf-16')
+        self.assertEndsWith(
+            context.exception.reason, 'invalid start byte')
+
+    def test_bytes_string_conversion_utf8_arbitrary(self):
+        """
+        Conversion to unicode will fail for ASCII/UTF-8 for an array of an
+        arbitrary size.
+        """
+        value = mk.bytes(8)
+
+        with self.assertRaises(UnicodeDecodeError) as context:
+            value.decode()
+
+        self.assertEndsWith(
+            context.exception.reason, 'ordinal not in range(128)')
+
+        with self.assertRaises(UnicodeDecodeError) as context:
+            value.decode(encoding='ascii')
+
+        self.assertEndsWith(
+            context.exception.reason, 'ordinal not in range(128)')
+
+        with self.assertRaises(UnicodeDecodeError) as context:
+            value.decode(encoding='utf-8')
+
+        self.assertEndsWith(
+            context.exception.reason, 'invalid start byte')
+
+    def test_bytes_string_conversion_utf16_default(self):
+        """
+        Conversion to unicode will succeed for UTF-16 for the default size.
+        """
+        value = mk.bytes()
+
+        value.decode(encoding='utf-16')
+
+    def test_bytes_string_conversion_utf16_valid(self):
+        """
+        Conversion to unicode will succeed for UTF-16 when an array of valid
+        size is used.
+        """
+        value = mk.bytes(16)
+
+        value.decode(encoding='utf-16')
+
+    def test_bytes_string_conversion_utf16_invalid(self):
+        """
+        Conversion to unicode will fail for UTF-16 when an invalid size
+        is used.
+        """
+        value = mk.bytes(size=15)
+
+        with self.assertRaises(UnicodeDecodeError) as context:
+            value.decode(encoding='utf-16')
+
+        self.assertEndsWith(
+            context.exception.reason, 'truncated data')
 
     class OneFactory(ChevahCommonsFactory):
         """

--- a/chevah/compat/tests/normal/testing/test_testcase.py
+++ b/chevah/compat/tests/normal/testing/test_testcase.py
@@ -617,6 +617,31 @@ class TestEmpiricalTestCase(EmpiricalTestCase):
                 'is True.'
                 )
 
+    @conditionals.onAdminPrivileges(True)
+    def test_onAdminPrivileges_present(self):
+        """
+        Run test only on machines that execute the tests with administrator
+        privileges.
+        """
+        if 'win-2003' in self.hostname:
+            raise AssertionError(
+                'Windows 2003 BS does not run as administrator')
+        elif 'win-xp' in self.hostname:
+            raise AssertionError('Windows XP BS does not run as administrator')
+
+    @conditionals.onAdminPrivileges(False)
+    def test_onAdminPrivileges_missing(self):
+        """
+        Run test on build slaves that do not have administrator privileges.
+        """
+        if 'win-2003' in self.hostname:
+            return
+        elif 'win-xp' in self.hostname:
+            return
+
+        raise AssertionError(
+            '"%s" is running with administrator privileges' % (self.hostname,))
+
     def test_cleanup_test_segments_file(self):
         """
         When self.test_segments is defined it will be automatically

--- a/chevah/empirical/conditionals.py
+++ b/chevah/empirical/conditionals.py
@@ -6,8 +6,9 @@ Decorators used for testing.
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from nose import SkipTest
 from functools import wraps
+from nose import SkipTest
+from socket import gethostname
 from unittest import TestCase
 
 from chevah.compat import process_capabilities
@@ -82,3 +83,26 @@ def onCapability(name, value):
 
     return skipOnCondition(
         check_capability, 'Capability "%s" not present.' % name)
+
+
+def onAdminPrivileges(present):
+    """
+    Run test only if administrator privileges match the `present` value on
+    the machine running the tests.
+
+    For the moment only Windows 2003 and Windows XP build slaves execute the
+    tests suite with a regular account.
+    """
+    hostname = gethostname()
+    is_running_as_admin = 'win-2003' in hostname or 'win-xp' in hostname
+
+    def check_administrator():
+        if present:
+            return is_running_as_admin
+
+        return not is_running_as_admin
+
+    return skipOnCondition(
+        check_administrator,
+        'Administrator privileges not present on "%s".' % (hostname,)
+        )

--- a/chevah/empirical/mockup.py
+++ b/chevah/empirical/mockup.py
@@ -421,7 +421,7 @@ class ResponseDefinition(object):
             self.persistent,
             )
 
-    def updateReponseContent(self, content):
+    def updateResponseContent(self, content):
         """
         Will update the content returned to the server.
         """

--- a/chevah/empirical/mockup.py
+++ b/chevah/empirical/mockup.py
@@ -483,9 +483,9 @@ class ChevahCommonsFactory(object):
         Returns a bytes array with random values that cannot be decoded
         as UTF-8.
         """
-        result = bytearray(b'\xff\xd8\x00\x01')
-        for _ in range(max(4, size - 4)):
-            result.append(random.getrandbits(8))
+        result = bytearray(b'\xff')
+        for _ in range(max(1, size - 1)):
+            result.append(random.getrandbits(4))
         return result
 
     def TCPPort(self, factory=None, address='', port=1234):

--- a/pavement.py
+++ b/pavement.py
@@ -66,7 +66,7 @@ BUILD_PACKAGES = [
     # Docutils is required for RST parsing and for Sphinx.
     'docutils==0.12.c1',
 
-    'twisted==15.5.0.chevah3',
+    'twisted==15.5.0.chevah4',
 
     # Buildbot is used for try scheduler
     'buildbot==0.8.11.c7',

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,7 +2,7 @@ Release notes for chevah.compat
 ===============================
 
 
-0.37.1 - 24/01/2017
+0.38.0 - 24/01/2017
 -------------------
 
 * Add conditional for skipping tests depending on availability of

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,14 @@ Release notes for chevah.compat
 ===============================
 
 
+0.37.1 - 24/01/2017
+-------------------
+
+* Add conditional for skipping tests depending on availability of
+  administrator privileges
+* Update empirical to the latest version
+
+
 0.37.0 - 23/01/2017
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.37.1'
+VERSION = '0.38.0'
 
 
 class PublishCommand(Command):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.37.0'
+VERSION = '0.37.1'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
Scope
=====

We want to be able to skip certain tests and testcases on machines that do not execute the testsuite with administrator privileges enabled.

For the moment only `Windows 2003` and `Windows XP` run tests as a regular user.

Changes
=======

I've used the hostname filter for lack of a better solution.

As a drive-by change I've added the assertions for byte array length.

----

>   <adiroiban>testele pica pe xp/2003 din cauza permisiunilor

The failing tests are skipped on BSes that do not have admin privileges in this branch. I will properly fix this in the already existing PR for impersonation once this is in.

>   <adiroiban>pe osx din cauza grupuli

That should have been skipped and postponed for a dedicated ticket.

>   <adiroiban>si pe aix din cauza UTF-16
>   <adiroiban>UTF-16 l-a lasa pentru https://github.com/chevah/empirical/pull/56/

You forgot to update the master branch for empirical and were missing the latest PR changes.

I've merged them in this one.

How to try and test the changes
===============================

reviewers: @adiroiban 

Please check that changes make sense.