### PR TITLE
[#3831] Make mockup compatible with py2.

### DIFF
--- a/chevah/compat/testing/mockup.py
+++ b/chevah/compat/testing/mockup.py
@@ -434,8 +434,11 @@ class ResponseDefinition(object):
         """
         Will update the content returned to the server.
         """
+        if not isinstance(content, bytes):
+            content = codecs.encode(content, 'utf-8')
+
         self.test_response_content = content
-        response_length = len(content)
+        response_length = len(self.test_response_content)
         self.response_length = str(response_length)
 
 

--- a/chevah/compat/testing/mockup.py
+++ b/chevah/compat/testing/mockup.py
@@ -8,9 +8,11 @@ from __future__ import absolute_import
 from builtins import str
 from builtins import range
 from builtins import object
+from future.utils import native
 
 from select import error as SelectError
 from threading import Thread
+import codecs
 import http.server
 import errno
 import hashlib
@@ -405,12 +407,14 @@ class ResponseDefinition(object):
         self.url = url
         self.method = method
         self.request = request
+        if not isinstance(response_content, bytes):
+            response_content = codecs.encode(response_content, 'utf-8')
         self.test_response_content = response_content
         self.response_code = response_code
         self.response_message = response_message
         self.content_type = content_type
         if response_length is None:
-            response_length = len(response_content)
+            response_length = len(self.test_response_content)
         self.response_length = str(response_length)
         self.persistent = persistent
         if response_persistent is None:
@@ -628,7 +632,8 @@ class ChevahCommonsFactory(object):
         """
         Return a unique (per session) ASCII string.
         """
-        return ('ascii_str' + str(self.getUniqueInteger())).encode('ascii')
+        return native(
+            ('ascii_str' + str(self.getUniqueInteger()).encode('utf-8')))
 
     def bytes(self, size=8):
         """
@@ -714,7 +719,7 @@ class ChevahCommonsFactory(object):
                     for ignore in range(extra_length)
                     )
 
-        return base + extra_text + TEST_NAME_MARKER
+        return native(base + extra_text + TEST_NAME_MARKER)
 
     def makeLocalTestFilesystem(self, avatar=None):
         if avatar is None:
@@ -742,7 +747,7 @@ class ChevahCommonsFactory(object):
     def makeFilename(self, length=32, prefix=u'', suffix=u''):
         '''Return a random valid filename.'''
         name = str(self.getUniqueInteger()) + TEST_NAME_MARKER
-        return prefix + name + ('a' * (length - len(name))) + suffix
+        return native(prefix + name + ('a' * (length - len(name))) + suffix)
 
     def makeIPv4Address(self, host='localhost', port=None, protocol='TCP'):
         """

--- a/chevah/compat/testing/testcase.py
+++ b/chevah/compat/testing/testcase.py
@@ -12,7 +12,6 @@ from builtins import str
 from builtins import range
 from builtins import object
 from contextlib import contextmanager
-from io import BytesIO
 import collections
 import inspect
 import threading
@@ -1341,39 +1340,6 @@ class ChevahTestCase(TwistedTestCase):
             interface.implementedBy(klass),
             u'Class %s does not implements interface %s.' % (
                 klass, interface))
-
-
-class CommandTestCase(ChevahTestCase):
-    '''A test case that catches sys.exit, sys.stdout and sys.stderr.
-
-    It is designed to be used for testing command line tools.
-    '''
-
-    def setUp(self):
-        '''Monkey patch the sys.stdout and sys.exit.'''
-        super(CommandTestCase, self).setUp()
-
-        def _fake_exit(exit_code):
-            '''Method for monkey patching sys.exit.'''
-            self.exit_code = exit_code
-
-        self.exit_code = None
-        self.test_stdout = BytesIO()
-        self.test_stderr = BytesIO()
-        self.sys_exit = sys.exit
-        self.sys_argv = sys.argv
-        sys.exit = _fake_exit
-        sys.stdout = self.test_stdout
-        sys.stderr = self.test_stderr
-
-    def tearDown(self):
-        self.callCleanup()
-        self.test_stdout.close()
-        sys.stdout = sys.__stdout__
-        sys.stderr = sys.__stderr__
-        sys.exit = self.sys_exit
-        sys.argv = self.sys_argv
-        super(CommandTestCase, self).tearDown()
 
 
 class FileSystemTestCase(ChevahTestCase):

--- a/chevah/compat/tests/elevated/testing/__init__.py
+++ b/chevah/compat/tests/elevated/testing/__init__.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2012 Adi Roiban.
 # See LICENSE for details.
 """
-Tests for empirical package executed under elevated accounts.
+Tests executed under elevated accounts.
 """

--- a/chevah/compat/tests/normal/test_system_users.py
+++ b/chevah/compat/tests/normal/test_system_users.py
@@ -7,7 +7,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 from builtins import str
-import sys
 
 from chevah.compat import (
     DefaultAvatar,
@@ -35,13 +34,11 @@ class TestSystemUsers(CompatTestCase):
         """
         self.assertProvides(IOSUsers, system_users)
 
+    @conditionals.onOSFamily('posix')
     def test_getHomeFolder_linux(self):
         """
         Check getHomeFolder on Linux.
         """
-        if not sys.platform.startswith('linux'):
-            raise self.skipTest()
-
         home_folder = system_users.getHomeFolder(
             username=mk.username)
 
@@ -98,17 +95,6 @@ class TestSystemUsers(CompatTestCase):
 
         self.assertEqual(pdc, test_pdc)
         self.assertEqual(name, username)
-
-    @conditionals.onOSName('osx')
-    def test_getHomeFolder_osx(self):
-        """
-        Check getHomeFolder for OSX.
-        """
-        home_folder = system_users.getHomeFolder(
-            username=mk.username)
-
-        self.assertEqual(u'/Users/' + mk.username, home_folder)
-        self.assertIsInstance(str, home_folder)
 
     def test_shadow_support_unix(self):
         """

--- a/chevah/compat/tests/normal/test_testing.py
+++ b/chevah/compat/tests/normal/test_testing.py
@@ -20,5 +20,5 @@ class TestFactory(ChevahTestCase):
         Check that avatar is created with unicode members.
         """
         avatar = mk.makeFilesystemApplicationAvatar()
-        self.assertTrue(type(avatar.name) is str)
-        self.assertTrue(type(avatar.home_folder_path) is str)
+        self.assertIsInstance(avatar.name, str)
+        self.assertIsInstance(avatar.home_folder_path, str)

--- a/pavement.py
+++ b/pavement.py
@@ -82,8 +82,6 @@ BUILD_PACKAGES = [
 
 
 TEST_PACKAGES = [
-    'chevah-empirical==0.38.1',
-
     'pyflakes==0.8.1',
     'pocketlint==1.4.4.c4',
 
@@ -249,7 +247,6 @@ def test_py3():
     sys.argv = sys.argv[:1]
     pave.python_command_normal.extend(['-3'])
 
-    warnings.filterwarnings('always', module='chevah.empirical')
     captured_warnings = []
 
     def capture_warning(
@@ -267,7 +264,7 @@ def test_py3():
 
     warnings.showwarning = capture_warning
 
-    sys.args = ['nose', 'chevah.empirical.tests.normal']
+    sys.args = ['nose', 'chevah.compat.tests.normal']
     runner = nose_main(exit=False)
     if not runner.success:
         print 'Test failed'

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.39.0'
+VERSION = '0.40.0'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
Scope
=====

The initial porting to py3 resulted in `mk` creating types from the future lib which broke our tests.

the new types from future are much better as they provide a strict interpretation of str vs bytes... but they break the chevah/server tests... so for now we make them backward compatible and after that we will update the chevah/server tests to work with the new types

Changes
=======

Update the code to use the `native` types.

I have removed the command test case as it was only used by the server code


How to try and test the changes
===============================

reviewers: @alibotean 

check that changes make sense