### PR TITLE
[#3860] Use default timeout from test case

### DIFF
--- a/chevah/compat/testing/testcase.py
+++ b/chevah/compat/testing/testcase.py
@@ -209,13 +209,10 @@ class TwistedTestCase(TestCase):
             'Reactor took more than %.2f seconds to execute.' % timeout)
         self._reactor_timeout_failure = failure
 
-    def _initiateTestReactor(self, timeout=None):
+    def _initiateTestReactor(self, timeout):
         """
         Do the steps required to initiate a reactor for testing.
         """
-        if timeout is None:
-            timeout = self.DEFERRED_TIMEOUT
-
         self._timeout_reached = False
 
         # Set up timeout.

--- a/chevah/compat/testing/testcase.py
+++ b/chevah/compat/testing/testcase.py
@@ -479,7 +479,7 @@ class TwistedTestCase(TestCase):
                         '%s' % (self._reactorQueueToString()))
                 break
 
-            # Look at writters buffers:
+            # Look at writers buffers:
             if len(reactor.getWriters()) > 0:
                 have_callbacks = True
                 continue

--- a/chevah/compat/testing/testcase.py
+++ b/chevah/compat/testing/testcase.py
@@ -95,6 +95,9 @@ class TwistedTestCase(TestCase):
     tests.
     """
 
+    # Number of second to wait for a deferred to have a result.
+    DEFERRED_TIMEOUT = 1
+
     # List of names for delayed calls which should not be considered as
     # required to wait for them when running the reactor.
     EXCEPTED_DELAYED_CALLS = []
@@ -206,10 +209,13 @@ class TwistedTestCase(TestCase):
             'Reactor took more than %.2f seconds to execute.' % timeout)
         self._reactor_timeout_failure = failure
 
-    def _initiateTestReactor(self, timeout=1):
+    def _initiateTestReactor(self, timeout=None):
         """
         Do the steps required to initiate a reactor for testing.
         """
+        if timeout is None:
+            timeout = self.DEFERRED_TIMEOUT
+
         self._timeout_reached = False
 
         # Set up timeout.
@@ -340,7 +346,7 @@ class TwistedTestCase(TestCase):
                 raise_failure('delayed calls', delayed_str)
 
     def runDeferred(
-            self, deferred, timeout=1, debug=False, prevent_stop=False):
+            self, deferred, timeout=None, debug=False, prevent_stop=False):
         """
         Run the deferred in the reactor loop.
 
@@ -366,6 +372,9 @@ class TwistedTestCase(TestCase):
         """
         if not isinstance(deferred, Deferred):
             raise AssertionError('This is not a deferred.')
+
+        if timeout is None:
+            timeout = self.DEFERRED_TIMEOUT
 
         try:
             self._initiateTestReactor(timeout=timeout)
@@ -394,7 +403,7 @@ class TwistedTestCase(TestCase):
             self._runDeferred(result, timeout=timeout, debug=debug)
             result = deferred.result
 
-    def executeReactor(self, timeout=1, debug=False, run_once=False):
+    def executeReactor(self, timeout=None, debug=False, run_once=False):
         """
         Run reactor until no more delayed calls, readers or
         writers or threads are in the queues.
@@ -421,6 +430,9 @@ class TwistedTestCase(TestCase):
 
             self.assertStartsWith('211-Features:\n', result)
         """
+        if timeout is None:
+            timeout = self.DEFERRED_TIMEOUT
+
         self._initiateTestReactor(timeout=timeout)
 
         # Set it to True to enter the first loop.
@@ -504,7 +516,7 @@ class TwistedTestCase(TestCase):
         return raw_name.split(' ', 1)[0]
 
     def getDeferredFailure(
-            self, deferred, timeout=1, debug=False, prevent_stop=False):
+            self, deferred, timeout=None, debug=False, prevent_stop=False):
         """
         Run the deferred and return the failure.
 
@@ -652,7 +664,7 @@ class TwistedTestCase(TestCase):
                     deferred, result[0]))
 
     def getDeferredResult(
-            self, deferred, timeout=1, debug=False, prevent_stop=False):
+            self, deferred, timeout=None, debug=False, prevent_stop=False):
         """
         Run the deferred and return the result.
 

--- a/chevah/compat/tests/normal/testing/test_testcase.py
+++ b/chevah/compat/tests/normal/testing/test_testcase.py
@@ -66,9 +66,9 @@ class TestTwistedTestCase(ChevahTestCase):
         self.assertEqual(
             'This is not a deferred.', context.exception.args[0])
 
-    def test_runDeferred_timeout(self):
+    def test_runDeferred_timeout_custom(self):
         """
-        runDeferred will execute the reactor and raise a timeout
+        runDeferred will execute the reactor and raise an exception
         if deferred got no result after the timeout.
         """
         deferred = defer.Deferred()
@@ -81,7 +81,27 @@ class TestTwistedTestCase(ChevahTestCase):
             context.exception.args[0]
             )
 
-        # Restore order order messing with internal timeout state in
+        # Restore order messing with internal timeout state in
+        # previous state.
+        self._reactor_timeout_failure = None
+
+    def test_runDeferred_timeout_default(self):
+        """
+        It will execute the reactor and raise an exception if the
+        default timeout passes and the deferred is not completed.
+        """
+        self.DEFERRED_TIMEOUT = 0
+        deferred = defer.Deferred()
+
+        with self.assertRaises(AssertionError) as context:
+            self.runDeferred(deferred)
+
+        self.assertEqual(
+            'Deferred took more than 0 to execute.',
+            context.exception.args[0]
+            )
+
+        # Restore order messing with internal timeout state in
         # previous state.
         self._reactor_timeout_failure = None
 
@@ -100,7 +120,7 @@ class TestTwistedTestCase(ChevahTestCase):
     def test_runDeferred_callbacks_list(self):
         """
         runDeferred will execute the reactor and wait for deferred
-        to return a non-deferred result from the deferrers callbacks list.
+        to return a non-deferred result from the deferreds callbacks list.
         """
         # We use an uncalled deferred, to make sure that callbacks are not
         # executed when we call addCallback.

--- a/chevah/compat/tests/normal/testing/test_testcase.py
+++ b/chevah/compat/tests/normal/testing/test_testcase.py
@@ -347,6 +347,28 @@ class TestTwistedTestCase(ChevahTestCase):
         self.executeReactor()
 
 
+class TestTwistedTimeoutTestCase(ChevahTestCase):
+    """
+    Test for the default timeout.
+    """
+
+    DEFERRED_TIMEOUT = 2
+
+    def test_executeReactor_default_timeout(self):
+        """
+        It will use the default timeout value defined on the test case.
+        """
+        self.called = False
+
+        def last_call():
+            self.called = True
+        reactor.callLater(1, last_call)
+
+        self.executeReactor()
+
+        self.assertTrue(self.called)
+
+
 class TestChevahTestCase(ChevahTestCase):
     """
     General tests for ChevahTestCase.

--- a/chevah/compat/tests/normal/testing/test_testcase.py
+++ b/chevah/compat/tests/normal/testing/test_testcase.py
@@ -374,7 +374,7 @@ class TestTwistedTimeoutTestCase(ChevahTestCase):
 
     DEFERRED_TIMEOUT = 2
 
-    def test_executeReactor_default_timeout(self):
+    def test_executeReactor_timeout_default(self):
         """
         It will use the default timeout value defined on the test case.
         """
@@ -385,6 +385,21 @@ class TestTwistedTimeoutTestCase(ChevahTestCase):
         reactor.callLater(1, last_call)
 
         self.executeReactor()
+
+        self.assertTrue(self.called)
+
+    def test_executeReactor_timeout_custom(self):
+        """
+        It will use the custom timeout value instead of the default,
+        test case value.
+        """
+        self.called = False
+
+        def last_call():
+            self.called = True
+        reactor.callLater(2, last_call)
+
+        self.executeReactor(timeout=3)
 
         self.assertTrue(self.called)
 

--- a/chevah/compat/tests/normal/testing/test_testcase.py
+++ b/chevah/compat/tests/normal/testing/test_testcase.py
@@ -326,6 +326,20 @@ class TestTwistedTestCase(ChevahTestCase):
         self.assertTrue(self.called)
         self.assertTrue(deferred.called)
 
+    def test_executeReactor_timeout_value(self):
+        """
+        It will use the requested timeout value for executing the reactor.
+        """
+        self.called = False
+
+        def last_call():
+            self.called = True
+        reactor.callLater(1.5, last_call)
+
+        self.executeReactor(timeout=2)
+
+        self.assertTrue(self.called)
+
     def test_assertReactorIsClean_excepted_deferred(self):
         """
         Will raise an error if a delayed call is still on the reactor queue.
@@ -372,7 +386,7 @@ class TestTwistedTimeoutTestCase(ChevahTestCase):
     Test for the default timeout.
     """
 
-    DEFERRED_TIMEOUT = 2
+    DEFERRED_TIMEOUT = 1.5
 
     def test_executeReactor_timeout_default(self):
         """
@@ -382,24 +396,9 @@ class TestTwistedTimeoutTestCase(ChevahTestCase):
 
         def last_call():
             self.called = True
-        reactor.callLater(1, last_call)
+        reactor.callLater(1.25, last_call)
 
         self.executeReactor()
-
-        self.assertTrue(self.called)
-
-    def test_executeReactor_timeout_custom(self):
-        """
-        It will use the custom timeout value instead of the default,
-        test case value.
-        """
-        self.called = False
-
-        def last_call():
-            self.called = True
-        reactor.callLater(2, last_call)
-
-        self.executeReactor(timeout=3)
 
         self.assertTrue(self.called)
 

--- a/paver.conf
+++ b/paver.conf
@@ -1,4 +1,4 @@
-BRINK_VERSION='0.55.25'
+BRINK_VERSION='0.58.0'
 PYTHON_VERSION='python2.7'
 BINARY_DIST_URI='http://binary.chevah.com/production'
 PIP_INDEX='http://pypi.chevah.com'

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,13 @@ Release notes for chevah.compat
 ===============================
 
 
+0.41.0 - 09/02/2017
+-------------------
+
+* The default timeout used to wait for a deferred is now defined by the test
+  class instance.
+
+
 0.40.0 - 27/01/2017
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.40.0'
+VERSION = '0.41.0'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
Scope
=====

This defines the default timeout for a deferred in the test case.

In this way you can increase the timeout for all tests inside a slow testcase... and we don't have to pass it to all call.


Changes
=======

Define and use deferred timeout as instance member.


How to try and test the changes
===============================

reviewers: @alibotean 

check that changes make sense

with this, we can update ServerTestCase with a default of 1.5 ... to see if we still have many tests fainling at random time due to slow deferred