### PR TITLE
[#3880] Don't fail for already done delayed calls.

### DIFF
--- a/chevah/compat/testing/testcase.py
+++ b/chevah/compat/testing/testcase.py
@@ -137,7 +137,7 @@ class TwistedTestCase(TestCase):
                 self.assertIsNone(self._reactor_timeout_failure)
                 self.assertReactorIsClean()
         finally:
-            self.cleanReactor()
+            self._cleanReactor()
         super(TwistedTestCase, self).tearDown()
 
     def _reactorQueueToString(self):
@@ -181,9 +181,12 @@ class TwistedTestCase(TestCase):
             return reactor.threadpool.working
 
     @classmethod
-    def cleanReactor(cls):
+    def _cleanReactor(cls):
         """
         Remove all delayed calls, readers and writers from the reactor.
+
+        This is only for cleanup purpose and should not be used by normal
+        tests.
         """
         if not reactor:
             return

--- a/chevah/compat/testing/testcase.py
+++ b/chevah/compat/testing/testcase.py
@@ -24,7 +24,6 @@ from bunch import Bunch
 from mock import patch, Mock
 from nose import SkipTest
 from twisted.internet.defer import Deferred
-from twisted.internet.error import AlreadyCalled, AlreadyCancelled
 from twisted.python.failure import Failure
 try:
     from twisted.internet.posixbase import (

--- a/chevah/compat/testing/testcase.py
+++ b/chevah/compat/testing/testcase.py
@@ -23,12 +23,13 @@ import time
 from bunch import Bunch
 from mock import patch, Mock
 from nose import SkipTest
+from twisted.internet.defer import Deferred
+from twisted.internet.error import AlreadyCalled, AlreadyCancelled
+from twisted.python.failure import Failure
 try:
-    from twisted.internet.defer import Deferred
     from twisted.internet.posixbase import (
         _SocketWaker, _UnixWaker, _SIGCHLDWaker
         )
-    from twisted.python.failure import Failure
 except ImportError:
     # Twisted support is optional.
     _SocketWaker = None
@@ -152,7 +153,7 @@ class TwistedTestCase(TestCase):
 
     def _threadPoolQueueSize(self):
         """
-        Return current size of thread Pool, or None when treadpool does not
+        Return current size of thread Pool, or None when threadpool does not
         exists.
         """
         if not reactor.threadpool:
@@ -162,7 +163,7 @@ class TwistedTestCase(TestCase):
 
     def _threadPoolThreads(self):
         """
-        Return current threads from pool, or None when treadpool does not
+        Return current threads from pool, or None when threadpool does not
         exists.
         """
         if not reactor.threadpool:
@@ -172,7 +173,7 @@ class TwistedTestCase(TestCase):
 
     def _threadPoolWorking(self):
         """
-        Return working thread from pool, or None when treadpool does not
+        Return working thread from pool, or None when threadpool does not
         exists.
         """
         if not reactor.threadpool:

--- a/chevah/compat/testing/testcase.py
+++ b/chevah/compat/testing/testcase.py
@@ -23,12 +23,12 @@ import time
 from bunch import Bunch
 from mock import patch, Mock
 from nose import SkipTest
-from twisted.internet.defer import Deferred
-from twisted.python.failure import Failure
 try:
+    from twisted.internet.defer import Deferred
     from twisted.internet.posixbase import (
         _SocketWaker, _UnixWaker, _SIGCHLDWaker
         )
+    from twisted.python.failure import Failure
 except ImportError:
     # Twisted support is optional.
     _SocketWaker = None

--- a/chevah/compat/tests/normal/testing/test_testcase.py
+++ b/chevah/compat/tests/normal/testing/test_testcase.py
@@ -384,8 +384,8 @@ class TestTwistedTestCase(ChevahTestCase):
         """
         It  will cancel any delayed calls in the reactor queue.
         """
-        reactor.callLater(1, lambda: None)
-        reactor.callLater(2, lambda: None)
+        reactor.callLater(1, self.ignoreFailure)
+        reactor.callLater(2, self.ignoreFailure)
         self.assertIsNotEmpty(reactor.getDelayedCalls())
 
         self._cleanReactor()
@@ -397,8 +397,8 @@ class TestTwistedTestCase(ChevahTestCase):
         It  will not break if a call is already called and will continue
         canceling the .
         """
-        delayed_call_1 = reactor.callLater(1, lambda: None)
-        delayed_call_2 = reactor.callLater(2, lambda: None)
+        delayed_call_1 = reactor.callLater(1, self.ignoreFailure)
+        delayed_call_2 = reactor.callLater(2, self.ignoreFailure)
         # Fake that deferred was called and make sure it is first in the list
         # so that we can can check that the operation will continue.
         delayed_call_1.called = True

--- a/chevah/compat/tests/normal/testing/test_testcase.py
+++ b/chevah/compat/tests/normal/testing/test_testcase.py
@@ -382,7 +382,7 @@ class TestTwistedTestCase(ChevahTestCase):
 
     def test_cleanReactor_delayed_calls_all_active(self):
         """
-        It  will cancel any delayed calls in the reactor queue.
+        It will cancel any delayed calls in the reactor queue.
         """
         reactor.callLater(1, self.ignoreFailure)
         reactor.callLater(2, self.ignoreFailure)
@@ -394,7 +394,7 @@ class TestTwistedTestCase(ChevahTestCase):
 
     def test_cleanReactor_delayed_calls_some_called(self):
         """
-        It  will not break if a call is already called and will continue
+        It will not break if a call is already called and will continue
         canceling the .
         """
         delayed_call_1 = reactor.callLater(1, self.ignoreFailure)

--- a/chevah/compat/tests/normal/testing/test_testcase.py
+++ b/chevah/compat/tests/normal/testing/test_testcase.py
@@ -408,6 +408,13 @@ class TestTwistedTestCase(ChevahTestCase):
         self._cleanReactor()
 
         self.assertTrue(delayed_call_2.cancelled)
+        # Since we are messing with the reactor, we are leaving it in an
+        # inconsistent state as no called delayed call should be part of the
+        # list... since when called, the delayed called is removed right
+        # away, yet we are not removing it but only faking its call.
+        delayed_call_1.called = False
+        self._cleanReactor()
+        self.assertIsEmpty(reactor.getDelayedCalls())
 
 
 class TestTwistedTimeoutTestCase(ChevahTestCase):

--- a/pavement.py
+++ b/pavement.py
@@ -92,6 +92,7 @@ TEST_PACKAGES = [
     # Never version of nose, hangs on closing some tests
     # due to some thread handling.
     'nose==1.3.6',
+    'nose-randomly==1.2.5',
     'mock',
 
     'coverage==4.0.3',
@@ -137,6 +138,11 @@ SETUP['pocket-lint']['include_folders'] = ['chevah/compat']
 SETUP['pocket-lint']['exclude_files'] = []
 SETUP['test']['package'] = 'chevah.compat.tests'
 SETUP['test']['elevated'] = 'elevated'
+SETUP['test']['nose_options'] = [
+    '--with-run-reporter',
+    '--with-timer',
+    '--with-randomly',
+    ]
 SETUP['buildbot']['server'] = 'buildbot.chevah.com'
 SETUP['buildbot']['web_url'] = 'https://buildbot.chevah.com:10443'
 SETUP['pypi']['index_url'] = 'http://pypi.chevah.com/simple'

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,12 @@ Release notes for chevah.compat
 ===============================
 
 
+0.41.1 - 21/02/2017
+-------------------
+
+* Fix cleanup code to not fail if a delayed called was already canceled.
+
+
 0.41.0 - 09/02/2017
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.41.0'
+VERSION = '0.41.1'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
Scope
=====

This fix the so that we don't see false errors in tearDown

Changes
=======

```
======================================================================
ERROR: test_get_non_empty_ascii_file - functional.test_ftp_transfer:TestDataChannelFTPSEActive.test_get_non_empty_ascii_file
----------------------------------------------------------------------
Traceback (most recent call last):
  File "c:/Users/domainbuildslave/chevah/bs/server-win-dc-client/build/chevah\server\testing\functional.py", line 163, in tearDown
    self.stopService()
  File "c:/Users/domainbuildslave/chevah/bs/server-win-dc-client/build/chevah\server\testing\functional.py", line 269, in stopService
    self.cleanReactor()
  File "c:\Users\domainbuildslave\chevah\bs\server-win-dc-client\build\build-windows-x86\lib\lib\site-packages\chevah\compat\testing\testcase.py", line 201, in cleanReactor
    delayed_call.cancel()
  File "c:\Users\domainbuildslave\chevah\bs\server-win-dc-client\build\build-windows-x86\lib\lib\site-packages\twisted\internet\base.py", line 89, in cancel
    raise error.AlreadyCalled
AlreadyCalled: Tried to cancel an already-called event.

```

I was not able reproduce this in a test...since this is a race condition due to threads but I wrote some kind of test to cover it.


How to try and test the changes
===============================

reviewers: @brunogola @alibotean 

this is an example why `if self.canDoX(): self.doX()` is not working with threads ... and we should just do `try: self.doX() except`