### PR TITLE
[#4048] Revert spwd code. Fix build system

### DIFF
--- a/chevah/compat/administration.py
+++ b/chevah/compat/administration.py
@@ -46,7 +46,7 @@ def execute(command, input_text=None, output=None, ignore_errors=True):
     Execute a command having stdout redirected and using 'input_text' as
     input.
     """
-    verbose = False
+    verbose = True
 
     if verbose:
         print('Calling: %s' % command)

--- a/chevah/compat/administration.py
+++ b/chevah/compat/administration.py
@@ -535,7 +535,6 @@ class OSAdministrationUnix(object):
             )
 
     def _setUserPassword_openbsd(self, user):
-        password = user.password.encode('utf-8')
         code, out = execute(
             command=['encrypt'],
             input_text=user.password.encode('utf-8'),

--- a/chevah/compat/administration.py
+++ b/chevah/compat/administration.py
@@ -235,9 +235,6 @@ class OSAdministrationUnix(object):
             '-M', members_list.encode('utf-8')])
 
     def _addUsersToGroup_openbsd(self, group, users):
-        if not len(users):
-            return
-
         group_name = group.name.encode('utf-8')
         for user in users:
             execute([

--- a/chevah/compat/interfaces.py
+++ b/chevah/compat/interfaces.py
@@ -600,7 +600,8 @@ class IFileAttributes(Interface):
     """
 
     name = Attribute('Name of this member.')
-    path = Attribute('Absolute path of this member.')
+    path = Attribute(
+        'Absolute path of this member, as seen for the chrooted fs.')
     size = Attribute('Size in bytes.')
     is_file = Attribute('True if member is a file.')
     is_folder = Attribute('True if member is a folder.')

--- a/chevah/compat/testing/filesystem.py
+++ b/chevah/compat/testing/filesystem.py
@@ -77,7 +77,8 @@ class LocalTestFilesystem(LocalFilesystem):
         """
         Remove temporary folder.
         """
-        self.deleteFolder(self.temp_segments, recursive=True)
+        if self.exists(self.temp_segments):
+            self.deleteFolder(self.temp_segments, recursive=True)
 
     @property
     def home_path(self):

--- a/chevah/compat/testing/mockup.py
+++ b/chevah/compat/testing/mockup.py
@@ -14,7 +14,6 @@ import hashlib
 import os
 import random
 import string
-import sys
 import uuid
 
 from unidecode import unidecode
@@ -59,10 +58,7 @@ def _sanitize_name_windows(candidate):
     return str(unidecode(candidate))
 
 
-class TestUser(object):
-    """
-    An object storing all user information.
-    """
+class SanitizeNameMixin(object):
 
     @classmethod
     def sanitizeName(cls, name):
@@ -76,6 +72,12 @@ class TestUser(object):
             return _sanitize_name_windows(name)
 
         return name
+
+
+class TestUser(SanitizeNameMixin):
+    """
+    An object storing all user information.
+    """
 
     def __init__(
         self, name, posix_uid=None, posix_gid=None, posix_home_path=None,
@@ -167,22 +169,10 @@ class TestUser(object):
         self._windows_token = None
 
 
-class TestGroup(object):
+class TestGroup(SanitizeNameMixin):
     """
     An object storing all group information.
     """
-
-    @classmethod
-    def sanitizeName(cls, group):
-        """
-        Return name sanitized for current OS.
-        """
-        if sys.platform.startswith('aix'):
-            return _sanitize_name_legacy_unix(group)
-        elif sys.platform.startswith('win'):
-            return _sanitize_name_windows(group)
-
-        return group
 
     def __init__(self, name, posix_gid=None, members=None, pdc=None):
         """

--- a/chevah/compat/testing/mockup.py
+++ b/chevah/compat/testing/mockup.py
@@ -70,7 +70,7 @@ class TestUser(object):
         Return name sanitized for current OS.
         """
         os_name = process_capabilities.os_name
-        if os_name in ['aix', 'hpux']:
+        if os_name in ['aix', 'hpux', 'freebsd', 'openbsd']:
             return _sanitize_name_legacy_unix(name)
         elif os_name == 'windows':
             return _sanitize_name_windows(name)

--- a/chevah/compat/tests/elevated/test_filesystem.py
+++ b/chevah/compat/tests/elevated/test_filesystem.py
@@ -483,6 +483,5 @@ class TestSymbolicLinks(OSAccountFileSystemTestCase, SymbolicLinksMixin):
         password=mk.string(),
         home_group=TEST_ACCOUNT_GROUP,
         posix_uid=mk.posixID(),
-        posix_gid=mk.posixID(),
         windows_required_rights=rights,
         )

--- a/chevah/compat/tests/elevated/test_system_users.py
+++ b/chevah/compat/tests/elevated/test_system_users.py
@@ -236,7 +236,7 @@ class TestSystemUsers(SystemUsersTestCase):
             password=TEST_ACCOUNT_PASSWORD,
             )
 
-        if self.os_name == 'osx':
+        if self.os_name in ['osx']:
             self.assertIsNone(result)
         else:
             self.assertTrue(result)

--- a/chevah/compat/tests/normal/test_capabilities.py
+++ b/chevah/compat/tests/normal/test_capabilities.py
@@ -79,6 +79,9 @@ class TestProcessCapabilitiesPosix(CompatTestCase):
             # FIXME:2745:
             # PAM is not yet supported on HPUX.
             self.assertFalse(self.capabilities.pam)
+        elif self.os_name == 'openbsd':
+            # OpenBSD does not has PAM by default.
+            self.assertFalse(self.capabilities.pam)
         else:
             self.assertTrue(self.capabilities.pam)
 

--- a/chevah/compat/tests/normal/test_filesystem.py
+++ b/chevah/compat/tests/normal/test_filesystem.py
@@ -978,6 +978,12 @@ class TestLocalFilesystem(CompatTestCase, FilesystemTestMixin):
             count = 45000
             base_timeout = 0.1
 
+        if self.os_name == 'windows':
+            # On windows, some iteration operation might be very slow.
+            bias = 0.7
+        else:
+            bias = 0
+
         base_segments = self.folderInTemp()
 
         for i in range(count):
@@ -998,7 +1004,7 @@ class TestLocalFilesystem(CompatTestCase, FilesystemTestMixin):
         result.append(next(iterator))
         try:
             while True:
-                with self.assertExecutionTime(base_timeout * 2):
+                with self.assertExecutionTime(base_timeout + bias):
                     result.append(next(iterator))
         except StopIteration:
             """

--- a/chevah/compat/tests/normal/test_filesystem.py
+++ b/chevah/compat/tests/normal/test_filesystem.py
@@ -998,7 +998,7 @@ class TestLocalFilesystem(CompatTestCase, FilesystemTestMixin):
         result.append(next(iterator))
         try:
             while True:
-                with self.assertExecutionTime(base_timeout):
+                with self.assertExecutionTime(base_timeout * 2):
                     result.append(next(iterator))
         except StopIteration:
             """

--- a/chevah/compat/tests/normal/test_filesystem.py
+++ b/chevah/compat/tests/normal/test_filesystem.py
@@ -996,7 +996,7 @@ class TestLocalFilesystem(CompatTestCase, FilesystemTestMixin):
         self.assertEqual(count, len(result))
 
         # Getting the iterator will not take long.
-        with self.assertExecutionTime(base_timeout):
+        with self.assertExecutionTime(base_timeout + bias):
             iterator = self.filesystem.iterateFolderContent(base_segments)
 
         # Iterating at any step will not take long.

--- a/chevah/compat/tests/normal/test_filesystem.py
+++ b/chevah/compat/tests/normal/test_filesystem.py
@@ -973,7 +973,7 @@ class TestLocalFilesystem(CompatTestCase, FilesystemTestMixin):
             # Some OS/FS does not allow more than 32765 members in a folder
             # and the slave is generally slow.
             count = 32000
-            base_timeout = 0.1
+            base_timeout = 0.15
         else:
             count = 45000
             base_timeout = 0.1

--- a/chevah/compat/unix_capabilities.py
+++ b/chevah/compat/unix_capabilities.py
@@ -78,6 +78,9 @@ class UnixProcessCapabilities(BaseProcessCapabilities):
         """
         See `IProcessCapabilities`.
         """
+        if self.os_name == 'openbsd':
+            return False
+
         if self.os_name == 'hpux':
             # FIXME:2745:
             # We don't yet support PAM on HPUX.

--- a/chevah/compat/unix_users.py
+++ b/chevah/compat/unix_users.py
@@ -316,18 +316,6 @@ class UnixUsers(CompatUsers):
         username = username.encode('utf-8')
         password = password.encode('utf-8')
 
-        def get_crypted_password(password, salt):
-            '''Return the crypted password based on salt.
-
-            salt can be an salted password.
-            '''
-            crypt_value = crypt.crypt(password, salt)
-            if os.sys.platform == 'sunos5' and crypt_value.startswith('$6$'):
-                # There is a bug in Python 2.5 and crypt add some extra
-                # values for shadow passwords of type 6.
-                crypt_value = crypt_value[:12] + crypt_value[20:]
-            return crypt_value
-
         try:
             with self._executeAsAdministrator():
                 crypted_password = spwd.getspnam(username).sp_pwd

--- a/codecov.yml
+++ b/codecov.yml
@@ -19,5 +19,5 @@ flags:
       - tests/
 
 comment:
-  layout: "header, diff, uncovered"
+  layout: "header, diff, files"
   behavior: default

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,6 +6,17 @@ coverage:
     patch:
       default:
         target: 100%
+    project:
+      default:
+        target: auto
+      tests:
+        target: 100%
+        flags: tests
+
+flags:
+  tests:
+    paths:
+      - tests/
 
 comment:
   layout: "header, diff, uncovered"

--- a/pavement.py
+++ b/pavement.py
@@ -239,7 +239,8 @@ def test_ci(args):
     """
     Run tests in continuous integration environment.
     """
-    default_args = [
+    # When running in CI mode, we want to get more reports.
+    SETUP['test']['nose_options'] += [
         '--with-run-reporter',
         '--with-timer',
         ]
@@ -257,9 +258,9 @@ def test_ci(args):
     env = os.environ.copy()
     args = env.get('TEST_ARGUMENTS', '')
     if not args:
-        args = default_args
+        args = []
     else:
-        args = [args] + default_args
+        args = [args]
     test_type = env.get('TEST_TYPE', 'normal')
 
     if test_type == 'os-independent':

--- a/paver.conf
+++ b/paver.conf
@@ -1,4 +1,4 @@
-BRINK_VERSION='0.60.4'
+BRINK_VERSION='0.60.5'
 PYTHON_CONFIGURATION='default@2.7.13.4f815b5:solaris10@2.7.8.4f815b5'
 BINARY_DIST_URI='http://binary.chevah.com/production'
 PIP_INDEX='http://pypi.chevah.com'

--- a/paver.conf
+++ b/paver.conf
@@ -1,4 +1,4 @@
-BRINK_VERSION='0.59.0'
+BRINK_VERSION='0.60.4'
 PYTHON_CONFIGURATION='default@2.7.13.4f815b5:solaris10@2.7.8.4f815b5'
 BINARY_DIST_URI='http://binary.chevah.com/production'
 PIP_INDEX='http://pypi.chevah.com'

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,12 @@ Release notes for chevah.compat
 ===============================
 
 
+0.43.1 - 04/05/2017
+-------------------
+
+* Fix bad shadow change in previous release.
+
+
 0.43.0 - 04/05/2017
 -------------------
 

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,12 @@ Release notes for chevah.compat
 ===============================
 
 
+0.43.2 - 05/05/2017
+-------------------
+
+* Fix OpenBSD/FreeBSD password authentication.
+
+
 0.43.1 - 04/05/2017
 -------------------
 

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,12 @@ Release notes for chevah.compat
 ===============================
 
 
+0.43.3 - 08/05/2017
+-------------------
+
+* Initialize the test case with a non-Unicode drop user name.
+
+
 0.43.2 - 05/05/2017
 -------------------
 

--- a/scripts/nose_runner.py
+++ b/scripts/nose_runner.py
@@ -43,7 +43,7 @@ def main():
     from chevah.compat.testing import ChevahTestCase
 
 
-    drop_user = sys.argv[1]
+    drop_user = sys.argv[1].encode('utf-8')
     ChevahTestCase.initialize(drop_user=drop_user)
     ChevahTestCase.dropPrivileges()
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.43.2'
+VERSION = '0.43.3'
 
 
 class PublishCommand(Command):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.43.1'
+VERSION = '0.43.2'
 
 
 class PublishCommand(Command):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.43.0'
+VERSION = '0.43.1'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
Scope
=====

This fix a bad change in previous PR.

The coverage was reporting a bug missing chunk... but  I have just ignored it thinking that is old code... well, it was some old code, but it was also some unintentional code which was removed... and a lot of tests which were not executed.

We really need to add a hard check and make sure we have 100% coverage for the tests


Changes
=======

Add back the code which was accidentally removed.

Update the build system to execute the elevated test.

This add proper password auth support for freebsd and openbsd... with support for create users and groupd


The master branch was updated in GitHub to be protected from the default tests and the coverage/project/tests... if they are not green , you can't merge it

I made a few changes to the coverage reporting

How to try and test the changes
===============================

reviewers: @brunogola 

check that changes make sense

I will try to update codecov to have a separate report for the coverage or the tests code itself