### PR TITLE
[#4353] Run cleanup in reverse order as they are added.

### DIFF
--- a/chevah/compat/administration.py
+++ b/chevah/compat/administration.py
@@ -809,7 +809,7 @@ class OSAdministrationWindows(OSAdministrationUnix):
         data = {'name': group.name}
         try:
             win32net.NetLocalGroupAdd(group.pdc, 0, data)
-        except Exception as error:
+        except Exception as error:  # pragma: no cover
             raise AssertionError(
                 'Failed to add group %s in domain %s. %s' % (
                     group.name, group.pdc, error))
@@ -830,7 +830,7 @@ class OSAdministrationWindows(OSAdministrationUnix):
         try:
             win32net.NetLocalGroupAddMembers(
                 group.pdc, group.name, 3, members_info)
-        except Exception as error:
+        except Exception as error:  # pragma: no cover
             raise AssertionError(
                 'Failed to add to group %s users %s. %s' % (
                     group.name, users, error))
@@ -861,7 +861,7 @@ class OSAdministrationWindows(OSAdministrationUnix):
 
         win32net.NetUserAdd(user.pdc, 1, user_info)
         if user.windows_create_local_profile:
-            if not user.password:
+            if not user.password:  # pragma: no cover
                 raise AssertionError('You must provide a password.')
 
             system_users._createLocalProfile(
@@ -891,7 +891,7 @@ class OSAdministrationWindows(OSAdministrationUnix):
             import win32net
             win32net.NetUserChangePassword(
                 pdc, user.name, user.password, user.password)
-        except Exception:
+        except Exception:  # pragma: no cover
             print('Failed to set password "%s" for user "%s" on pdc "%s".' % (
                 user.password, user.name, pdc))
             raise
@@ -907,7 +907,7 @@ class OSAdministrationWindows(OSAdministrationUnix):
         import win32net
         try:
             win32net.NetUserDel(user.pdc, user.name)
-        except win32net.error as error:
+        except win32net.error as error:  # pragma: no cover
             # Ignore user not found error.
             (number, context, message) = error
             # Ignore user not found error.
@@ -933,7 +933,7 @@ class OSAdministrationWindows(OSAdministrationUnix):
         # names.
         command = u'rmdir /S /Q "%s"' % profile_folder_path
         result = subprocess.call(command.encode('utf-8'), shell=True)
-        if result != 0:
+        if result != 0:  # pragma: no cover
             message = u'Unable to remove folder [%s]: %s\n%s.' % (
                 result, profile_folder_path, command)
             raise AssertionError(message.encode('utf-8'))
@@ -971,7 +971,7 @@ class OSAdministrationWindows(OSAdministrationUnix):
         try:
             result = win32security.LookupAccountName('', user.name)
             user_sid = result[0]
-        except win32security.error:
+        except win32security.error:  # pragma: no cover
             message = u'User %s could not be found.' % (user.name)
             raise AssertionError(message.encode('utf-8'))
 

--- a/chevah/compat/administration.py
+++ b/chevah/compat/administration.py
@@ -827,8 +827,13 @@ class OSAdministrationWindows(OSAdministrationUnix):
             members_info.append({
                 'domainandname': member
                 })
-        win32net.NetLocalGroupAddMembers(
-            group.pdc, group.name, 3, members_info)
+        try:
+            win32net.NetLocalGroupAddMembers(
+                group.pdc, group.name, 3, members_info)
+        except Exception as error:
+            raise AssertionError(
+                'Failed to add to group %s users %s. %s' % (
+                    group.name, users, error))
 
     def addUser(self, user):
         """

--- a/chevah/compat/testing/__init__.py
+++ b/chevah/compat/testing/__init__.py
@@ -9,7 +9,7 @@ Here are a few import shortcuts.
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import str
+from __future__ import unicode_literals
 from future import standard_library
 
 from remote_pdb import RemotePdb
@@ -32,21 +32,21 @@ CompatTestCase = ChevahTestCase
 mk
 
 # Test accounts and passwords.
-TEST_ACCOUNT_USERNAME = str(u'mâț mițișor')
-TEST_ACCOUNT_PASSWORD = str(u'Baroșanu42!')
-TEST_ACCOUNT_GROUP = str(u'g mâțmițișor')
+TEST_ACCOUNT_USERNAME = 'mâț mițișor'
+TEST_ACCOUNT_PASSWORD = 'Baroșanu42!'
+TEST_ACCOUNT_GROUP = 'g mâțmițișor'
 # FIXME:2106:
 # Replace hard-coded constant with posixID()
 TEST_ACCOUNT_UID = 2000
 TEST_ACCOUNT_GID = 2010
-TEST_ACCOUNT_GROUP_WIN = str(u'Users')
-TEST_ACCOUNT_USERNAME_OTHER = str(u'miț motan')
-TEST_ACCOUNT_PASSWORD_OTHER = str(u'altapara')
+TEST_ACCOUNT_GROUP_WIN = 'Users'
+TEST_ACCOUNT_USERNAME_OTHER = 'miț motan'
+TEST_ACCOUNT_PASSWORD_OTHER = 'altapara'
 # FIXME:2106:
 # Replace hard-coded constant with posixID()
 TEST_ACCOUNT_UID_OTHER = 2001
 TEST_ACCOUNT_GID_OTHER = 2011
-TEST_ACCOUNT_GROUP_OTHER = str(u'g mițmotan')
+TEST_ACCOUNT_GROUP_OTHER = 'g mițmotan'
 
 # Another test group to test an user belonging to multiple groups.
 TEST_ACCOUNT_GROUP_ANOTHER = u'g-another-test'
@@ -55,11 +55,11 @@ TEST_ACCOUNT_GROUP_ANOTHER = u'g-another-test'
 TEST_ACCOUNT_GID_ANOTHER = 2012
 
 # Domain controller helpers.
-TEST_PDC = str(u'\\\\CHEVAH-DC')
-TEST_DOMAIN = str(u'chevah')
-TEST_ACCOUNT_USERNAME_DOMAIN = str(u'domain test-user')
-TEST_ACCOUNT_PASSWORD_DOMAIN = str(u'qwe123QWE')
-TEST_ACCOUNT_GROUP_DOMAIN = str(u'domain test_group')
+TEST_PDC = '\\\\CHEVAH-DC'
+TEST_DOMAIN = 'chevah'
+TEST_ACCOUNT_USERNAME_DOMAIN = 'domain test-user'
+TEST_ACCOUNT_PASSWORD_DOMAIN = 'qwe123QWE'
+TEST_ACCOUNT_GROUP_DOMAIN = 'domain test_group'
 
 TEST_ACCOUNT_USERNAME = TestUser.sanitizeName(TEST_ACCOUNT_USERNAME)
 TEST_ACCOUNT_GROUP = TestGroup.sanitizeName(TEST_ACCOUNT_GROUP)
@@ -77,15 +77,15 @@ TEST_ACCOUNT_GROUP_DOMAIN = TestGroup.sanitizeName(
 
 
 if process_capabilities.os_name == 'solaris':
-    TEST_ACCOUNT_HOME_PATH = u'/export/home/' + TEST_ACCOUNT_USERNAME
+    TEST_ACCOUNT_HOME_PATH = '/export/home/' + TEST_ACCOUNT_USERNAME
     TEST_ACCOUNT_HOME_PATH_OTHER = (
-        u'/export/home/' + TEST_ACCOUNT_USERNAME_OTHER)
+        '/export/home/' + TEST_ACCOUNT_USERNAME_OTHER)
 else:
-    TEST_ACCOUNT_HOME_PATH = u'/home/' + TEST_ACCOUNT_USERNAME
-    TEST_ACCOUNT_HOME_PATH_OTHER = u'/home/' + TEST_ACCOUNT_USERNAME_OTHER
+    TEST_ACCOUNT_HOME_PATH = '/home/' + TEST_ACCOUNT_USERNAME
+    TEST_ACCOUNT_HOME_PATH_OTHER = '/home/' + TEST_ACCOUNT_USERNAME_OTHER
 
 TEST_USERS = {
-    u'normal': TestUser(
+    'normal': TestUser(
         name=TEST_ACCOUNT_USERNAME,
         posix_uid=TEST_ACCOUNT_UID,
         posix_gid=TEST_ACCOUNT_GID,
@@ -94,7 +94,7 @@ TEST_USERS = {
         home_group=TEST_ACCOUNT_GROUP,
         password=TEST_ACCOUNT_PASSWORD,
         ),
-    u'other': TestUser(
+    'other': TestUser(
         name=TEST_ACCOUNT_USERNAME_OTHER,
         posix_uid=TEST_ACCOUNT_UID_OTHER,
         posix_gid=TEST_ACCOUNT_GID_OTHER,
@@ -105,17 +105,17 @@ TEST_USERS = {
     }
 
 TEST_GROUPS = {
-    u'normal': TestGroup(
+    'normal': TestGroup(
         name=TEST_ACCOUNT_GROUP,
         posix_gid=TEST_ACCOUNT_GID,
         members=[TEST_ACCOUNT_USERNAME, TEST_ACCOUNT_USERNAME_OTHER],
         ),
-    u'other': TestGroup(
+    'other': TestGroup(
         name=TEST_ACCOUNT_GROUP_OTHER,
         posix_gid=TEST_ACCOUNT_GID_OTHER,
         members=[TEST_ACCOUNT_USERNAME_OTHER],
         ),
-    u'another': TestGroup(
+    'another': TestGroup(
         name=TEST_ACCOUNT_GROUP_ANOTHER,
         posix_gid=TEST_ACCOUNT_GID_ANOTHER,
         members=[TEST_ACCOUNT_USERNAME],

--- a/chevah/compat/testing/mockup.py
+++ b/chevah/compat/testing/mockup.py
@@ -55,7 +55,7 @@ def _sanitize_name_windows(candidate):
     """
     # FIXME:927:
     # On Windows, we can't delete home folders with unicode names.
-    return str(unidecode(candidate))
+    return unidecode(candidate)
 
 
 class SanitizeNameMixin(object):

--- a/chevah/compat/testing/testcase.py
+++ b/chevah/compat/testing/testcase.py
@@ -743,6 +743,10 @@ def _get_os_version():
         parts = platform.mac_ver()[0].split('.')
         return 'osx-%s.%s' % (parts[0], parts[1])
 
+    if os_name == 'sunos':
+        parts = platform.release().split('.')
+        return 'solaris-%s' % (parts[1],)
+
     if os_name == 'aix':
         return 'aix-%s.%s' % (platform.version(), platform.release())
 

--- a/chevah/compat/testing/testcase.py
+++ b/chevah/compat/testing/testcase.py
@@ -840,7 +840,7 @@ class ChevahTestCase(TwistedTestCase, AssertionMixin):
         """
         Call all cleanup methods.
         """
-        for function, args, kwargs in self.__cleanup__:
+        for function, args, kwargs in reversed(self.__cleanup__):
             function(*args, **kwargs)
         self.__cleanup__ = []
 

--- a/chevah/compat/tests/elevated/__init__.py
+++ b/chevah/compat/tests/elevated/__init__.py
@@ -39,7 +39,7 @@ def setup_package():
     # Initialize the testing OS.
     try:
         setup_access_control(users=TEST_USERS, groups=TEST_GROUPS)
-    except Exception:
+    except Exception:  # pragma: no cover
         import traceback
         print(traceback.format_exc())
         print("Failed to initialized the system accounts!")

--- a/chevah/compat/tests/elevated/__init__.py
+++ b/chevah/compat/tests/elevated/__init__.py
@@ -35,8 +35,8 @@ def setup_package():
     # Don't run these tests if we can not access privileged OS part.
     if not runElevatedTest():
         raise CompatTestCase.skipTest()
-    # Initialize the testing OS.
 
+    # Initialize the testing OS.
     try:
         setup_access_control(users=TEST_USERS, groups=TEST_GROUPS)
     except Exception:

--- a/chevah/compat/tests/normal/testing/test_testcase.py
+++ b/chevah/compat/tests/normal/testing/test_testcase.py
@@ -715,16 +715,23 @@ class TestChevahTestCaseAddCleanup(ChevahTestCase):
     def tearDown(self):
         self.assertEqual(0, self.cleanup_call_count)
         super(TestChevahTestCaseAddCleanup, self).tearDown()
-        self.assertEqual(1, self.cleanup_call_count)
+        self.assertEqual(2, self.cleanup_call_count)
 
-    def cleanUp(self):
+    def cleanUpLast(self):
+        self.assertEqual(1, self.cleanup_call_count)
+        self.cleanup_call_count += 1
+
+    def cleanUpFirst(self):
+        self.assertEqual(0, self.cleanup_call_count)
         self.cleanup_call_count += 1
 
     def test_addCleanup(self):
         """
-        Will be called at tearDown.
+        Will call the cleanup method at tearDown in the revere order
+        in which they were added.
         """
-        self.addCleanup(self.cleanUp)
+        self.addCleanup(self.cleanUpLast)
+        self.addCleanup(self.cleanUpFirst)
 
         self.assertEqual(0, self.cleanup_call_count)
 

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,10 +2,16 @@ Release notes for chevah.compat
 ===============================
 
 
+0.44.4 - 24/09/2017
+-------------------
+
+* Fix cleanup to call the cleanups in reverse order which they were added.
+
+
 0.44.3 - 06/08/2017
 -------------------
 
-* Update MD5 checsum to match the changes in getFileMD5Sum.
+* Update MD5 checksum to match the changes in getFileMD5Sum.
 
 
 0.44.2 - 06/08/2017

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.44.3'
+VERSION = '0.44.4'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
Scope
=====

This fix the cleanup code which should call the cleanup in reverse order.


Changes
=======

Run in reverse.

As a drive by, I have start moving away from python-future as it is bad :) and just use unicode_literals


How to try and test the changes
===============================

reviewers: @lgheorghiu 

Not much to test. Here for compliance as there is no one else to review