### PR TITLE
[#4468] Fix getAttributes on Windows for broken links.

### DIFF
--- a/chevah/compat/nt_filesystem.py
+++ b/chevah/compat/nt_filesystem.py
@@ -386,7 +386,18 @@ class NTFilesystem(PosixFilesystemBase):
         return type(stats)(stats_list)
 
     def getAttributes(self, segments):
-        '''See `ILocalFilesystem`.'''
+        """
+        See `ILocalFilesystem`.
+        """
+        if not self.exists(segments):
+            # On Windows, it will return the attributes, even if the target
+            # does not exists.
+            raise OSError(
+                errno.ENOENT,
+                'No such file or directory',
+                self.getRealPathFromSegments(segments),
+                )
+
         with self._windowsToOSError(segments):
             return super(NTFilesystem, self).getAttributes(segments)
 

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,12 @@ Release notes for chevah.compat
 ===============================
 
 
+0.45.2 - 08/11/2017
+-------------------
+
+* Fix getAttributes for broken link on Windows to return file not found.
+
+
 0.45.1 - 27/10/2017
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.45.1'
+VERSION = '0.45.2'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
Scope
=====

getAttributes will success on Windows when link is broken, but will fail on Unix.

This unifies the behaviour.


Changes
=======

For windows, check that path exists before getting attributes


How to try and test the changes
===============================

reviewers: @bgola 

check that changes make sense