### PR TITLE
[#4588] Add option to except thread names on ChevahTestCase tearDown.

### DIFF
--- a/chevah/compat/testing/assertion.py
+++ b/chevah/compat/testing/assertion.py
@@ -33,6 +33,9 @@ class Contains(object):
     def __init__(self, value):
         self.value = value
 
+    def __eq__(self, other):
+        return self.value in other
+
 
 class AssertionMixin(object):
     """

--- a/chevah/compat/testing/assertion.py
+++ b/chevah/compat/testing/assertion.py
@@ -36,7 +36,7 @@ class Contains(object):
     def __eq__(self, other):
         return self.value in other
 
-    def __hash__(self):
+    def __hash__(self):  # noqa:cover
         return hash(self.value)
 
 

--- a/chevah/compat/testing/assertion.py
+++ b/chevah/compat/testing/assertion.py
@@ -36,6 +36,9 @@ class Contains(object):
     def __eq__(self, other):
         return self.value in other
 
+    def __hash__(self):
+        return hash(self.value)
+
 
 class AssertionMixin(object):
     """

--- a/chevah/compat/testing/testcase.py
+++ b/chevah/compat/testing/testcase.py
@@ -40,7 +40,7 @@ from chevah.compat import (
     SuperAvatar,
     )
 from chevah.compat.administration import os_administration
-from chevah.compat.testing.assertion import AssertionMixin
+from chevah.compat.testing.assertion import AssertionMixin, Contains
 from chevah.compat.testing.mockup import mk
 from chevah.compat.testing.constants import (
     TEST_NAME_MARKER,
@@ -792,10 +792,11 @@ class ChevahTestCase(TwistedTestCase, AssertionMixin):
     os_version = _get_os_version()
     cpu_type = _get_cpu_type()
 
+    # List of thread names to ignore during the tearDown.
     excepted_threads = [
         'MainThread',
         'threaded_reactor',
-        'PoolThread-twisted.internet.reactor',
+        Contains('PoolThread-twisted.internet.reactor'),
         ]
 
     # We assume that hostname does not change during test and this
@@ -826,10 +827,6 @@ class ChevahTestCase(TwistedTestCase, AssertionMixin):
             for thread in threads:
                 thread_name = thread.getName()
                 if thread_name in self.excepted_threads:
-                    continue
-                if ('PoolThread-twisted.internet.reactor' in
-                        self.excepted_threads and thread_name.startswith(
-                        'PoolThread-twisted.internet.reactor')):
                     continue
 
                 raise AssertionError(

--- a/chevah/compat/testing/testcase.py
+++ b/chevah/compat/testing/testcase.py
@@ -792,6 +792,12 @@ class ChevahTestCase(TwistedTestCase, AssertionMixin):
     os_version = _get_os_version()
     cpu_type = _get_cpu_type()
 
+    excepted_threads = [
+        'MainThread',
+        'threaded_reactor',
+        'PoolThread-twisted.internet.reactor',
+        ]
+
     # We assume that hostname does not change during test and this
     # should save a few DNS queries.
     hostname = _get_hostname()
@@ -819,12 +825,11 @@ class ChevahTestCase(TwistedTestCase, AssertionMixin):
             # an exception here.
             for thread in threads:
                 thread_name = thread.getName()
-                if thread_name == 'MainThread':
+                if thread_name in self.excepted_threads:
                     continue
-                if thread_name == 'threaded_reactor':
-                    continue
-                if thread_name.startswith(
-                        'PoolThread-twisted.internet.reactor'):
+                if ('PoolThread-twisted.internet.reactor' in
+                        self.excepted_threads and thread_name.startswith(
+                        'PoolThread-twisted.internet.reactor')):
                     continue
 
                 raise AssertionError(

--- a/chevah/compat/tests/normal/test_testing.py
+++ b/chevah/compat/tests/normal/test_testing.py
@@ -7,7 +7,11 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 from six import text_type
+from threading import Thread, Event
+
 from chevah.compat.testing import ChevahTestCase, mk
+
+import time
 
 
 class TestFactory(ChevahTestCase):
@@ -22,3 +26,53 @@ class TestFactory(ChevahTestCase):
         avatar = mk.makeFilesystemApplicationAvatar()
         self.assertIsInstance(avatar.name, text_type)
         self.assertIsInstance(avatar.home_folder_path, text_type)
+
+    def test_tearDown_excepted_threads(self):
+        """
+        Will not fail if a thread name is in excepted_threads.
+        """
+        event = Event()
+
+        class TestThread(Thread):
+            def run(self):
+                event.wait()
+
+        old_excepted_threads = self.excepted_threads[:]
+        self.excepted_threads = self.excepted_threads + ['TestThread']
+
+        thread = TestThread(name="TestThread")
+        thread.start()
+
+        self.tearDown()
+
+        self.assertTrue(thread.is_alive())
+        event.set()
+
+        # Wait for the thread to stop.
+        time.sleep(0.1)
+        self.assertFalse(thread.is_alive())
+
+        self.excepted_threads = old_excepted_threads[:]
+
+    def test_tearDown_not_excepted_threads(self):
+        """
+        Will raise AssertioError fail if a thread name is not in
+        excepted_threads.
+        """
+        event = Event()
+
+        class TestThread(Thread):
+            def run(self):
+                event.wait()
+
+        thread = TestThread(name="TestThread")
+        thread.start()
+
+        with self.assertRaises(AssertionError) as context:
+            self.tearDown()
+
+        self.assertContains('TestThread', context.exception.message)
+
+        # Stop the thread.
+        event.set()
+        time.sleep(0.1)

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -1,6 +1,11 @@
 Release notes for chevah.compat
 ===============================
 
+0.46.0 - 19/12/2017
+-------------------
+
+* Add option to ignore thread names during the tearDown of ChevahTestCase.
+
 
 0.45.2 - 08/11/2017
 -------------------

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.45.2'
+VERSION = '0.46.0'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
Scope
=====

This adds an option to ignore certain threads during the tearDown.


Changes
=======

Added a class attribute to ChevahTestCase that can be overridden by subclasses / other test cases.


How to try and test the changes
===============================

reviewers: @adiroiban 


Please check if it makes sense. Thanks!