### PR TITLE
[#4753] Always iterate the reactor with timeout.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 *.pyc
-build/
-build-*/
-dist/
+/build/
+/build-*
+/dist/
 *.egg-info/
-DEFAULT_VALUES
-cache/
+/DEFAULT_VALUES
+/cache

--- a/chevah/compat/testing/testcase.py
+++ b/chevah/compat/testing/testcase.py
@@ -498,10 +498,12 @@ class TwistedTestCase(TestCase):
 
         self._shutdownTestReactor()
 
-
     def executeDelayedCalls(self, timeout=None, debug=False):
         """
         Run the reactor until no more delayed calls are scheduled.
+
+        This will wait for delayed calls to be executed and will not stop
+        the reactor.
         """
         if timeout is None:
             timeout = self.DEFERRED_TIMEOUT

--- a/chevah/compat/testing/testcase.py
+++ b/chevah/compat/testing/testcase.py
@@ -302,7 +302,7 @@ class TwistedTestCase(TestCase):
             raise AssertionError(
                 'Reactor is not clean. %s: %s' % (location, reason))
 
-        if reactor._started:
+        if reactor._started:  # noqa:cover
             # Reactor was not stopped, so stop it before raising the error.
             self._shutdownTestReactor()
             raise AssertionError('Reactor was not stopped.')

--- a/chevah/compat/testing/testcase.py
+++ b/chevah/compat/testing/testcase.py
@@ -228,7 +228,7 @@ class TwistedTestCase(TestCase):
         Iterate the reactor.
         """
         reactor.runUntilCurrent()
-        if debug:
+        if debug:  # noqa:cover
             # When debug is enabled with iterate using a small delay in steps,
             # to have a much better debug output.
             # Otherwise the debug messages will flood the output.
@@ -258,7 +258,8 @@ class TwistedTestCase(TestCase):
             t = reactor.running and t2
             reactor.doIteration(t)
         else:
-            reactor.doIteration(False)
+            # To not slow down all the tests, we run with a very small value.
+            reactor.doIteration(0.000001)
 
     def _shutdownTestReactor(self, prevent_stop=False):
         """
@@ -496,6 +497,79 @@ class TwistedTestCase(TestCase):
                 continue
 
         self._shutdownTestReactor()
+
+
+    def executeDelayedCalls(self, timeout=None, debug=False):
+        """
+        Run the reactor until no more delayed calls are scheduled.
+        """
+        if timeout is None:
+            timeout = self.DEFERRED_TIMEOUT
+
+        self._initiateTestReactor(timeout=timeout)
+        while not self._timeout_reached:
+            self._iterateTestReactor(debug=debug)
+            delayed_calls = reactor.getDelayedCalls()
+            try:
+                delayed_calls.remove(self._reactor_timeout_call)
+            except ValueError:  # noqa:cover
+                # Timeout might be no longer be there.
+                pass
+            if not delayed_calls:
+                break
+        self._shutdownTestReactor(prevent_stop=True)
+
+    def executeReactorUntil(
+            self, callable, timeout=None, debug=False, prevent_stop=True):
+        """
+        Run the reactor until callable returns `True`.
+        """
+        if timeout is None:
+            timeout = self.DEFERRED_TIMEOUT
+
+        self._initiateTestReactor(timeout=timeout)
+
+        while not self._timeout_reached:
+            self._iterateTestReactor(debug=debug)
+            if callable(reactor):
+                break
+
+        self._shutdownTestReactor(prevent_stop=prevent_stop)
+
+    def iterateReactor(self, count=1, timeout=None, debug=False):
+        """
+        Iterate the reactor without stopping it.
+        """
+        iterations = [False] * (count - 1)
+        iterations.append(True)
+        self.executeReactorUntil(
+            lambda _: iterations.pop(0), timeout=timeout, debug=debug)
+
+    def iterateReactorWithStop(self, count=1, timeout=None, debug=False):
+        """
+        Iterate the reactor and stop it at the end.
+        """
+        iterations = [False] * (count - 1)
+        iterations.append(True)
+        self.executeReactorUntil(
+            lambda _: iterations.pop(0),
+            timeout=timeout,
+            debug=debug,
+            prevent_stop=False,
+            )
+
+    def iterateReactorForSeconds(self, duration=1, debug=False):
+        """
+        Iterate the reactor for `duration` seconds..
+        """
+        start = time.time()
+
+        self.executeReactorUntil(
+            lambda _: time.time() - start > duration,
+            timeout=duration + 0.1,
+            debug=debug,
+            prevent_stop=False,
+            )
 
     def _getDelayedCallName(self, delayed_call):
         """
@@ -1101,6 +1175,35 @@ class ChevahTestCase(TwistedTestCase, AssertionMixin):
             callback(*args, **kwargs)
 
         return context.exception
+
+    def tempFile(self, content='', prefix='', suffix=''):
+        """
+        Return (path, segments) for a new file created in temp which is
+        auto cleaned.
+        """
+        segments = mk.fs.createFileInTemp(prefix=prefix, suffix=suffix)
+        path = mk.fs.getRealPathFromSegments(segments)
+
+        self.addCleanup(mk.fs.deleteFile, segments)
+
+        try:
+            opened_file = mk.fs.openFileForWriting(segments, utf8=False)
+            opened_file.write(content)
+        finally:
+            opened_file.close()
+
+        return (path, segments)
+
+    def tempFolder(self, name=None, prefix='', suffix=''):
+        """
+        Create a new temp folder and return its path and segments, which is
+        auto cleaned.
+        """
+        segments = mk.fs.createFolderInTemp(
+            foldername=name, prefix=prefix, suffix=suffix)
+        path = mk.fs.getRealPathFromSegments(segments)
+        self.addCleanup(mk.fs.deleteFolder, segments)
+        return (path, segments)
 
 
 class FileSystemTestCase(ChevahTestCase):

--- a/chevah/compat/testing/testcase.py
+++ b/chevah/compat/testing/testcase.py
@@ -303,6 +303,8 @@ class TwistedTestCase(TestCase):
                 'Reactor is not clean. %s: %s' % (location, reason))
 
         if reactor._started:
+            # Reactor was not stopped, so stop it before raising the error.
+            self._shutdownTestReactor()
             raise AssertionError('Reactor was not stopped.')
 
         # Look at threads queue.
@@ -520,6 +522,12 @@ class TwistedTestCase(TestCase):
             if not delayed_calls:
                 break
         self._shutdownTestReactor(prevent_stop=True)
+        if self._reactor_timeout_failure is not None:
+            self._reactor_timeout_failure = None
+            # We stop the reactor on failures.
+            self._shutdownTestReactor()
+            raise AssertionError(
+                'executeDelayedCalls took more than %s' % (timeout,))
 
     def executeReactorUntil(
             self, callable, timeout=None, debug=False, prevent_stop=True):

--- a/chevah/compat/tests/normal/test_filesystem.py
+++ b/chevah/compat/tests/normal/test_filesystem.py
@@ -407,24 +407,24 @@ class TestLocalFilesystem(CompatTestCase, FilesystemTestMixin):
         Can be used for linking a file.
         """
         content = mk.string()
-        self.test_segments = mk.fs.createFileInTemp(content=content)
-        link_segments = self.test_segments[:]
-        link_segments[-1] = '%s-link' % self.test_segments[-1]
+        _, segments = self.tempFile(content=content.encode('utf-8'))
+        link_segments = segments[:]
+        link_segments[-1] = '%s-link' % segments[-1]
 
         mk.fs.makeLink(
-            target_segments=self.test_segments,
+            target_segments=segments,
             link_segments=link_segments,
             )
 
         self.assertTrue(mk.fs.exists(link_segments))
         self.assertTrue(mk.fs.isLink(link_segments))
         # Will point to the same content.
-        link_content = mk.fs.getFileContent(self.test_segments)
+        link_content = mk.fs.getFileContent(segments)
         self.assertEqual(content, link_content)
         # Can be removed as a simple file and target file is not removed.
         mk.fs.deleteFile(link_segments)
         self.assertFalse(mk.fs.exists(link_segments))
-        self.assertTrue(mk.fs.exists(self.test_segments))
+        self.assertTrue(mk.fs.exists(segments))
 
     @conditionals.onCapability('symbolic_link', True)
     def test_makeLink_folder(self):
@@ -619,10 +619,10 @@ class TestLocalFilesystem(CompatTestCase, FilesystemTestMixin):
         """
         Check isFile.
         """
-        self.test_segments = mk.fs.createFileInTemp()
+        _, segments = self.tempFile()
         _, non_existent_segments = mk.fs.makePathInTemp()
 
-        self.assertTrue(self.filesystem.isFile(self.test_segments))
+        self.assertTrue(self.filesystem.isFile(segments))
         # Non existent paths are not files.
         self.assertFalse(self.filesystem.isFile(non_existent_segments))
         # Folders are not files.
@@ -715,9 +715,9 @@ class TestLocalFilesystem(CompatTestCase, FilesystemTestMixin):
         """
         Check attributes for a folder.
         """
-        self.test_segments = mk.fs.createFolderInTemp()
+        _, segments = self.tempFolder()
 
-        attributes = self.filesystem.getAttributes(self.test_segments)
+        attributes = self.filesystem.getAttributes(segments)
 
         self.assertTrue(attributes.is_folder)
         self.assertFalse(attributes.is_file)

--- a/chevah/compat/tests/normal/testing/test_testcase.py
+++ b/chevah/compat/tests/normal/testing/test_testcase.py
@@ -298,7 +298,7 @@ class TestTwistedTestCase(ChevahTestCase):
         self.called = False
 
         def last_call():
-            time.sleep(0.2)
+            time.sleep(0.5)
             self.called = True
 
         deferred = threads.deferToThread(last_call)

--- a/paver.conf
+++ b/paver.conf
@@ -1,4 +1,4 @@
-BASE_REQUIREMENTS='chevah-brink==0.67.2 paver==1.2.4'
-PYTHON_CONFIGURATION='default@2.7.14.8f78f41f:solaris10@2.7.8.8f78f41f'
+BASE_REQUIREMENTS='chevah-brink==0.68.0 paver==1.2.4'
+PYTHON_CONFIGURATION='default@2.7.14.620df8b0:solaris10@2.7.8.c3d8a7d:aix71@2.7.13.25cf4cf:rhel7openssl101@2.7.10.8fa7d09'
 BINARY_DIST_URI='http://binary.chevah.com/production'
 PIP_INDEX='http://pypi.chevah.com'

--- a/paver.sh
+++ b/paver.sh
@@ -84,19 +84,13 @@ clean_build() {
     echo "Cleaning project temporary files..."
     rm -f DEFAULT_VALUES
     echo "Cleaning pyc files ..."
-    if [ $OS = "rhel4" ]; then
-        # RHEL 4 don't support + option in -exec
-        # We use -print0 and xargs to no fork for each file.
-        # find will fail if no file is found.
-        touch ./dummy_file_for_RHEL4.pyc
-        find ./ -name '*.pyc' -print0 | xargs -0 rm
-    else
-        # AIX's find complains if there are no matching files when using +.
-        [ $(uname) == AIX ] && touch ./dummy_file_for_AIX.pyc
-        # Faster than '-exec rm {} \;' and supported in most OS'es,
-        # details at http://www.in-ulm.de/~mascheck/various/find/#xargs
-        find ./ -name '*.pyc' -exec rm {} +
-    fi
+
+    # AIX's find complains if there are no matching files when using +.
+    [ $(uname) == AIX ] && touch ./dummy_file_for_AIX.pyc
+    # Faster than '-exec rm {} \;' and supported in most OS'es,
+    # details at http://www.in-ulm.de/~mascheck/various/find/#xargs
+    find ./ -name '*.pyc' -exec rm {} +
+
     # In some case pip hangs with a build folder in temp and
     # will not continue until it is manually removed.
     # On the OSX build server tmp is in $TMPDIR
@@ -578,6 +572,18 @@ detect_os() {
                     cat /etc/redhat-release | sed s/.*release// | cut -d' ' -f2)
                 check_os_version "Red Hat Enterprise Linux" 4 \
                     "$os_version_raw" os_version_chevah
+
+                # RHEL 7.4 and newer have OpenSSL 1.0.2, while 7.3 and older
+                # have version 1.0.1. Thus for the older RHEL 7 versions we use
+                # a separate OS signature, to make use of a dedicated Python
+                # package.
+                if [ "$os_version_chevah" -eq 7 ]; then
+                    if openssl version | grep -F -q "1.0.1"; then
+                        # We are on 1.0.1 which is pre RHEL 7.4
+                        os_version_chevah=7openssl101
+                    fi
+                fi
+
                 OS="rhel${os_version_chevah}"
             fi
         elif [ -f /etc/SuSE-release ]; then

--- a/paver.sh
+++ b/paver.sh
@@ -396,7 +396,7 @@ copy_python() {
                 # Remove it and try to install it again.
                 echo "Updating Python from" \
                     $python_installed_version to $PYTHON_VERSION
-                rm -rf ${BUILD_FOLDER}
+                rm -rf ${BUILD_FOLDER}/*
                 rm -rf ${python_distributable}
                 copy_python
             fi
@@ -410,7 +410,7 @@ copy_python() {
                 echo "Updating Python from UNVERSIONED to $PYTHON_VERSION"
                 # We have a different python installed.
                 # Remove it and try to install it again.
-                rm -rf ${BUILD_FOLDER}
+                rm -rf ${BUILD_FOLDER}/*
                 rm -rf ${python_distributable}
                 copy_python
             else
@@ -570,9 +570,8 @@ detect_os() {
             if egrep -q 'Red\ Hat|CentOS|Scientific' /etc/redhat-release; then
                 os_version_raw=$(\
                     cat /etc/redhat-release | sed s/.*release// | cut -d' ' -f2)
-                check_os_version "Red Hat Enterprise Linux" 4 \
+                check_os_version "Red Hat Enterprise Linux" 5 \
                     "$os_version_raw" os_version_chevah
-
                 # RHEL 7.4 and newer have OpenSSL 1.0.2, while 7.3 and older
                 # have version 1.0.1. Thus for the older RHEL 7 versions we use
                 # a separate OS signature, to make use of a dedicated Python
@@ -583,7 +582,6 @@ detect_os() {
                         os_version_chevah=7openssl101
                     fi
                 fi
-
                 OS="rhel${os_version_chevah}"
             fi
         elif [ -f /etc/SuSE-release ]; then
@@ -599,10 +597,6 @@ detect_os() {
                     OS="sles11sm"
                 fi
             fi
-        elif [ -f /etc/arch-release ]; then
-            # Arch Linux is a rolling distro, no version info available.
-            # Beware that there's no version to get from /etc/os-release either!
-            OS="archlinux"
         elif [ -f /etc/os-release ]; then
             source /etc/os-release
             linux_distro="$ID"
@@ -633,6 +627,10 @@ detect_os() {
                     check_os_version "$distro_fancy_name" 3.6 \
                         "$os_version_raw" os_version_chevah
                     OS="alpine${os_version_chevah}"
+                    ;;
+                "arch")
+                    # Arch Linux is a rolling distro, no version info available.
+                    OS="archlinux"
                     ;;
             esac
         fi

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -1,6 +1,16 @@
 Release notes for chevah.compat
 ===============================
 
+0.47.0 - 08/03/2018
+-------------------
+
+* Iterate the reactor with a timeout and not with None.
+  When iterating with None we have observed that not all tasks are executed
+  by the reactor, especially closing the connections.
+* Add helper functions to create temporary file and folders with auto cleanup.
+* Add helpers for spinning the reactor in various conditions.
+
+
 0.46.0 - 19/12/2017
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.46.0'
+VERSION = '0.47.0'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
Scope
=====

This is an import for some changes which were done in chevah/server but which should have been here.


Changes
=======

Use a small timeout instead of None for reactor iteration.

As a drive by I moved more functions to compat and wrote tests, as in chevah/server they were just used, but without dedicated tests.

How to try and test the changes
===============================

reviewers: @bgola 

check that changes make sense

thanks
