### PR TITLE
[#4681] Add support for UNC and links to Windows Shares.

### DIFF
--- a/chevah/compat/interfaces.py
+++ b/chevah/compat/interfaces.py
@@ -427,6 +427,8 @@ class ILocalFilesystem(Interface):
         """
         Return True if segments points to an existing path.
 
+        It will return True for broken links.
+
         This should check that a file exists without reading the file or folder
         in order to not trigger errors due to permissions errors.
         """
@@ -525,6 +527,10 @@ class ILocalFilesystem(Interface):
     def getAttributes(segments):
         """
         Return a list of IFileAttributes for segment.
+
+        If the path is a link, it will return the attributes for the link.
+
+        Return file not found when the link is broken.
         """
 
     def setAttributes(segments, attributes):

--- a/chevah/compat/interfaces.py
+++ b/chevah/compat/interfaces.py
@@ -548,7 +548,7 @@ class ILocalFilesystem(Interface):
 
     def readLink(segments):
         """
-        Return the value of link at `segments'.
+        Return the value in segments of link at `segments'.
         """
 
     def makeLink(target_segments, link_segments):

--- a/chevah/compat/interfaces.py
+++ b/chevah/compat/interfaces.py
@@ -426,6 +426,9 @@ class ILocalFilesystem(Interface):
     def exists(segments):
         """
         Return True if segments points to an existing path.
+
+        This should check that a file exists without reading the file or folder
+        in order to not trigger errors due to permissions errors.
         """
 
     def createFolder(segments, recursive):

--- a/chevah/compat/nt_filesystem.py
+++ b/chevah/compat/nt_filesystem.py
@@ -460,7 +460,7 @@ class NTFilesystem(PosixFilesystemBase):
                     raise error
 
                 result.size = stats.st_size
-                result.modified =stats.st_mtime
+                result.modified = stats.st_mtime
                 result.mode = stats.st_mode
 
             return result

--- a/chevah/compat/nt_filesystem.py
+++ b/chevah/compat/nt_filesystem.py
@@ -235,6 +235,10 @@ class NTFilesystem(PosixFilesystemBase):
 
         head = True
 
+        if path.startswith('\\\\?\\'):
+            # We have a long UNC and we normalize.
+            path = path[4:]
+
         if self._avatar.lock_in_home_folder:
             path = os.path.abspath(path)
             self._checkChildPath(self._getRootPath(), path)
@@ -242,10 +246,6 @@ class NTFilesystem(PosixFilesystemBase):
             tail = path[len(self._getRootPath()):]
             drive = ''
         else:
-
-            if path.startswith('\\\\?\\'):
-                # We have a long UNC and we normalize.
-                path = path[4:]
 
             if path.startswith('\\\\'):
                 # We have a network share.

--- a/chevah/compat/posix_filesystem.py
+++ b/chevah/compat/posix_filesystem.py
@@ -230,7 +230,7 @@ class PosixFilesystemBase(object):
         path = self.getRealPathFromSegments(segments)
         path_encoded = self.getEncodedPath(path)
         with self._impersonateUser():
-            return os.path.exists(path_encoded)
+            return os.path.lexists(path_encoded)
 
     def createFolder(self, segments, recursive=False):
         '''See `ILocalFilesystem`.'''

--- a/chevah/compat/posix_filesystem.py
+++ b/chevah/compat/posix_filesystem.py
@@ -737,9 +737,11 @@ class PosixFilesystemBase(object):
         ending = offset + symbolic_link_data['substitute_name_length']
         target_path = (
             symbolic_link_data['data'][offset:ending].decode('utf-16'))
-        # Have no idea why we get this magic marker.
+
+        # Have no idea why we get this marker, but we convert it to
+        # long UNC.
         if target_path.startswith('\\??\\'):
-            target_path = target_path[4:]
+            target_path = '\\\\?' + target_path[3:]
         result['target'] = target_path
 
         return result

--- a/chevah/compat/testing/conditionals.py
+++ b/chevah/compat/testing/conditionals.py
@@ -41,6 +41,8 @@ def skipOnCondition(callback, message):
         if callback():
             result.__unittest_skip__ = True
             result.__unittest_skip_why__ = message
+        else:
+            result.__unittest_skip__ = True
 
         return result
 

--- a/chevah/compat/testing/filesystem.py
+++ b/chevah/compat/testing/filesystem.py
@@ -151,11 +151,11 @@ class LocalTestFilesystem(LocalFilesystem):
         from chevah.compat.testing import mk
         return mk.makeFilename(prefix=prefix, suffix=suffix)
 
-    def makePathInTemp(self):
+    def makePathInTemp(self, prefix=u'', suffix=u''):
         """
         Return a (path, segments) that can be created in the temporary folder.
         """
-        name = self._makeFilename()
+        name = self._makeFilename(prefix=prefix, suffix=suffix)
         segments = self.temp_segments
         segments.append(name)
         path = os.path.join(self.temp_path, name)

--- a/chevah/compat/testing/testcase.py
+++ b/chevah/compat/testing/testcase.py
@@ -1186,6 +1186,12 @@ class ChevahTestCase(TwistedTestCase, AssertionMixin):
 
         return context.exception
 
+    def tempPath(self, prefix='', suffix=''):
+        """
+        Return (path, segments) for a path which is not created yet.
+        """
+        return mk.fs.makePathInTemp(prefix=prefix, suffix=suffix)
+
     def tempFile(self, content='', prefix='', suffix=''):
         """
         Return (path, segments) for a new file created in temp which is

--- a/chevah/compat/tests/mixin/filesystem.py
+++ b/chevah/compat/tests/mixin/filesystem.py
@@ -52,7 +52,8 @@ class SymbolicLinksMixin(object):
 
         self.addCleanup(self.filesystem.deleteFile, segments)
         self.assertTrue(self.filesystem.isLink(segments))
-        self.assertFalse(self.filesystem.exists(segments))
+        # Exists will check for the existence of the file itself.
+        self.assertTrue(self.filesystem.exists(segments))
 
     @conditionals.onCapability('symbolic_link', True)
     def test_makeLink_invalid_link(self):

--- a/chevah/compat/tests/normal/test_capabilities.py
+++ b/chevah/compat/tests/normal/test_capabilities.py
@@ -281,8 +281,8 @@ class TestNTProcessCapabilitiesNormalUser(CompatTestCase):
         self.assertNotContains('SeImpersonatePrivilege', text)
 
         # Slave which don't run as admin have no SE_BACKUP/SE_RESTORE
-        self.assertContains('SeBackupPrivilege:0', text)
-        self.assertContains('SeRestorePrivilege', text)
+        self.assertNotContains('SeBackupPrivilege:0', text)
+        self.assertNotContains('SeRestorePrivilege', text)
 
         if self.os_version in 'nt-5.1':
             # Windows XP has SE_CREATE_GLOBAL enabled even when

--- a/chevah/compat/tests/normal/test_capabilities.py
+++ b/chevah/compat/tests/normal/test_capabilities.py
@@ -289,7 +289,7 @@ class TestNTProcessCapabilitiesNormalUser(CompatTestCase):
             # running without administrator privileges.
             self.assertContains('SeCreateGlobalPrivilege:3', text)
         else:
-            # Windows 2003 is not admin
+            # Windows 2003 is not admin.
             self.assertNotContains('SeCreateGlobalPrivilege', text)
 
 

--- a/chevah/compat/tests/normal/test_capabilities.py
+++ b/chevah/compat/tests/normal/test_capabilities.py
@@ -263,9 +263,9 @@ class TestNTProcessCapabilitiesNormalUser(CompatTestCase):
         """
         result = self.capabilities.create_home_folder
 
-        # Windows XP does not have SE_BACKUP/SE_RESTORE enabled when not
-        # running with administrator privileges.
-        if self.os_version == 'nt-5.1':
+        # Windows XP and 2003 slaves are setup without "Backup Operators"
+        # group (SE_BACKUP/SE_RESTORE) enabled.
+        if self.os_version in ['nt-5.1', 'nt-5.2']:
             self.assertFalse(result)
         else:
             self.assertTrue(result)

--- a/chevah/compat/tests/normal/test_capabilities.py
+++ b/chevah/compat/tests/normal/test_capabilities.py
@@ -280,16 +280,17 @@ class TestNTProcessCapabilitiesNormalUser(CompatTestCase):
         self.assertNotContains('SeCreateSymbolicLinkPrivilege', text)
         self.assertNotContains('SeImpersonatePrivilege', text)
 
-        if self.os_version == 'nt-5.1':
+        # Slave which don't run as admin have no SE_BACKUP/SE_RESTORE
+        self.assertContains('SeBackupPrivilege:0', text)
+        self.assertContains('SeRestorePrivilege', text)
+
+        if self.os_version in 'nt-5.1':
             # Windows XP has SE_CREATE_GLOBAL enabled even when
             # running without administrator privileges.
             self.assertContains('SeCreateGlobalPrivilege:3', text)
         else:
             # Windows 2003 is not admin
             self.assertNotContains('SeCreateGlobalPrivilege', text)
-            # But the slave should be set up with SE_BACKUP/SE_RESTORE
-            self.assertContains('SeBackupPrivilege:0', text)
-            self.assertContains('SeRestorePrivilege', text)
 
 
 @conditionals.onOSFamily('nt')

--- a/chevah/compat/tests/normal/test_filesystem.py
+++ b/chevah/compat/tests/normal/test_filesystem.py
@@ -20,9 +20,9 @@ from chevah.compat.interfaces import IFileAttributes, ILocalFilesystem
 from chevah.compat.testing import CompatTestCase, conditionals, mk
 
 
-class FilesystemTestMixin(object):
+class FilesystemTestingHelpers(object):
     """
-    Common code for filesystem tests.
+    Common code for running filesystem tests.
     """
 
     def makeLink(self, segments, cleanup=True):
@@ -63,6 +63,12 @@ class FilesystemTestMixin(object):
             }
         win32net.NetShareAdd(None, 2, share_info_2)
         self.addCleanup(win32net.NetShareDel, None, name)
+
+
+class FilesystemTestMixin(FilesystemTestingHelpers):
+    """
+    Common tests for filesystem.
+    """
 
     def test_getSegments_upper_paths(self):
         """

--- a/chevah/compat/tests/normal/test_filesystem.py
+++ b/chevah/compat/tests/normal/test_filesystem.py
@@ -2524,6 +2524,9 @@ class TestLocalFilesystemLockedUNC(CompatTestCase, FilesystemTestMixin):
 
     @classmethod
     def setUpClass(cls):
+        if cls.__unittest_skip__:
+            raise cls.skipTest()
+
         cls.locked_avatar = DefaultAvatar()
         cls._share_name = 'TestLocalFilesystemLockedUNC ' + mk.string()
         cls.addWindowsShare('c:\\temp', cls._share_name)

--- a/chevah/compat/tests/normal/test_filesystem.py
+++ b/chevah/compat/tests/normal/test_filesystem.py
@@ -2159,6 +2159,7 @@ class TestLocalFilesystemUnlocked(CompatTestCase, FilesystemTestMixin):
         self.assertTrue(self.unlocked_filesystem.isLink(self.test_segments))
 
     @conditionals.onOSFamily('nt')
+    @conditionals.onCapability('symbolic_link', True)
     def test_exists_share_link(self):
         """
         Will return True when we have a UNC / network link.
@@ -2178,6 +2179,7 @@ class TestLocalFilesystemUnlocked(CompatTestCase, FilesystemTestMixin):
         self.assertTrue(result)
 
     @conditionals.onOSFamily('nt')
+    @conditionals.onCapability('symbolic_link', True)
     def test_exists_broken_share_link(self):
         """
         Will return True when we have a UNC / network link, even when it

--- a/chevah/compat/tests/normal/test_filesystem.py
+++ b/chevah/compat/tests/normal/test_filesystem.py
@@ -508,7 +508,7 @@ class TestLocalFilesystem(DefaultFilesystemTestCase):
 
     @conditionals.onOSFamily('nt')
     @conditionals.onCapability('symbolic_link', True)
-    def ttest_makeLink_windows_share_invalid(self):
+    def test_makeLink_windows_share_invalid(self):
         """
         It can create links to a non-existent Windows share.
         """
@@ -519,7 +519,7 @@ class TestLocalFilesystem(DefaultFilesystemTestCase):
             target_segments=['UNC', '127.0.0.1', share_name],
             link_segments=segments,
             )
-        self.addCleanup(self.filesystem.deleteFile, segments)
+        self.addCleanup(self.filesystem.deleteFolder, segments)
 
         self.assertTrue(os.path.exists(path))
         self.assertEqual(

--- a/chevah/compat/tests/normal/test_filesystem.py
+++ b/chevah/compat/tests/normal/test_filesystem.py
@@ -2433,6 +2433,23 @@ class TestLocalFilesystemLocked(CompatTestCase, FilesystemTestMixin):
         self.assertTrue(self.locked_filesystem.exists(link_segments))
 
     @conditionals.onCapability('symbolic_link', True)
+    def test_readLink_inside_home(self):
+        """
+        It return the virtual link of the target.
+        """
+        path, target_segments = self.tempFile()
+        link_segments = ['%s-link' % target_segments[-1]]
+        mk.fs.makeLink(
+            target_segments=target_segments,
+            link_segments=target_segments[:-1] + link_segments,
+            )
+        self.addCleanup(self.locked_filesystem.deleteFile, link_segments)
+
+        result = self.locked_filesystem.readLink(link_segments)
+
+        self.assertEqual(target_segments[-1:], result)
+
+    @conditionals.onCapability('symbolic_link', True)
     def test_readLink_outside_home(self):
         """
         Raise an error when target is outside of locked folder to not

--- a/pavement.py
+++ b/pavement.py
@@ -86,7 +86,7 @@ BUILD_PACKAGES = [
 
 # Packages required by the static analysis tests.
 LINT_PACKAGES = [
-    'scame==0.3.3',
+    'scame==0.4.2',
     'pyflakes==1.5.0',
     'pycodestyle==2.3.1',
     'bandit==1.4.0',
@@ -109,7 +109,6 @@ TEST_PACKAGES = [
     'mock',
 
     'coverage==4.4.1',
-    'coverator==0.1.0',
 
     # used for remote debugging.
     'remote_pdb==1.2.0',

--- a/pavement.py
+++ b/pavement.py
@@ -154,7 +154,7 @@ test_super
 try:
     from scame.formatcheck import ScameOptions
 
-    class ServerScameOptions(ScameOptions):
+    class CompatScameOptions(ScameOptions):
         """
         Scame options for the this project.
         """
@@ -177,8 +177,9 @@ try:
 
             return getattr(self, option)
 
-    options = ServerScameOptions()
+    options = CompatScameOptions()
     options.max_line_length = 80
+    options.progress = True
 
     options.scope = {
         'include': [

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,13 @@ Release notes for chevah.compat
 ===============================
 
 
+0.49.2 - 02/04/2018
+-------------------
+
+* ILocalFilesystem.getAttributes on Windows raise an error for broken links
+  and return the size and modified date of the linked file.
+
+
 0.49.1 - 02/04/2018
 -------------------
 

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -1,6 +1,13 @@
 Release notes for chevah.compat
 ===============================
 
+
+0.49.1 - 02/04/2018
+-------------------
+
+* ILocalFilesystem.exist no longer follows links.
+
+
 0.49.0 - 30/04/2018
 -------------------
 

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -1,6 +1,12 @@
 Release notes for chevah.compat
 ===============================
 
+0.49.0 - 30/04/2018
+-------------------
+
+* Add support for working with UNC paths and symbolic links to Windows shares.
+
+
 0.48.0 - 15/04/2018
 -------------------
 

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,14 +2,23 @@ Release notes for chevah.compat
 ===============================
 
 
-0.49.2 - 02/04/2018
+0.49.3 - 08/05/2018
+-------------------
+
+* Fix ILocalFilesystem.getSegmentsFromRealPath on Windows when dealing with
+  long UNC paths for locked filesystems.
+  In previous releases a long UNC was erroneously considered outside of the
+  base path.
+
+
+0.49.2 - 02/05/2018
 -------------------
 
 * ILocalFilesystem.getAttributes on Windows raise an error for broken links
   and return the size and modified date of the linked file.
 
 
-0.49.1 - 02/04/2018
+0.49.1 - 02/05/2018
 -------------------
 
 * ILocalFilesystem.exist no longer follows links.

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.49.1'
+VERSION = '0.49.2'
 
 
 class PublishCommand(Command):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.48.0'
+VERSION = '0.49.0'
 
 
 class PublishCommand(Command):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.49.2'
+VERSION = '0.49.3'
 
 
 class PublishCommand(Command):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.49.0'
+VERSION = '0.49.1'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
Scope
=====

This fix tha path handling to work with UNC paths and be able to work with symbolic links to Windows Shares.

Changes
=======

Add support for UNC.
Links to Windows Shares always exist.


How to try and test the changes
===============================

reviewers: @dumol 

This is just to check that compat is green on the supported platform.

Also check that the supported platforms are marked as "Required" in github.

Thanks!