### PR TITLE
[#4969] Add support for virtual folders.

### DIFF
--- a/chevah/compat/avatar.py
+++ b/chevah/compat/avatar.py
@@ -22,13 +22,15 @@ class FilesystemAvatar(HasImpersonatedAvatar):
 
     def __init__(
         self, name, home_folder_path, root_folder_path=None,
-        lock_in_home_folder=True, token=None
+        lock_in_home_folder=True, token=None,
+        virtual_folders=(),
             ):
         self._name = name
         self._home_folder_path = home_folder_path
         self._root_folder_path = root_folder_path
         self._token = token
         self._lock_in_home_folder = lock_in_home_folder
+        self._virtual_folders = virtual_folders
 
         if not isinstance(self._home_folder_path, text_type):
             raise RuntimeError('home_folder_path should be text.')
@@ -72,6 +74,13 @@ class FilesystemAvatar(HasImpersonatedAvatar):
         '''Return avatar's name.'''
         return self._name
 
+    @property
+    def virtual_folders(self):
+        """
+        See: :class:`IFileSystemAvatar`
+        """
+        return self._virtual_folders
+
 
 class FilesystemOSAvatar(FilesystemAvatar):
     """
@@ -90,7 +99,7 @@ class FilesystemOSAvatar(FilesystemAvatar):
 
 class FilesystemApplicationAvatar(FilesystemAvatar):
     """
-    Application avatar interacting with thefilesystem.
+    Application avatar interacting with the filesystem.
     """
 
     @property
@@ -98,6 +107,6 @@ class FilesystemApplicationAvatar(FilesystemAvatar):
         """
         See: :class:`IAvatarBase`
 
-        ApplicationAvatar can not be impersoanted.
+        ApplicationAvatar can not be impersonated.
         """
         return False

--- a/chevah/compat/interfaces.py
+++ b/chevah/compat/interfaces.py
@@ -382,8 +382,8 @@ class ILocalFilesystem(Interface):
         """
         Return the real path for the segments.
 
-        If `no_virtual_root` is True, it will return None if segments are
-        for the root of virtual folder.
+        If `no_virtual_root` is True, it will return VIRTUAL_ROOT if segments
+        are for the root of virtual folder.
         """
 
     def getSegmentsFromRealPath(real_path):

--- a/chevah/compat/interfaces.py
+++ b/chevah/compat/interfaces.py
@@ -382,7 +382,7 @@ class ILocalFilesystem(Interface):
         """
         Return the real path for the segments.
 
-        Raises and error when `include_virtual` is False and the segments
+        Raises an error when `include_virtual` is False and the segments
         are for a real path.
         """
 

--- a/chevah/compat/interfaces.py
+++ b/chevah/compat/interfaces.py
@@ -378,12 +378,12 @@ class ILocalFilesystem(Interface):
     home_segments = Attribute('Segments for user home folder.')
     temp_segments = Attribute('Segments to temp folder.')
 
-    def getRealPathFromSegments(segments, no_virtual_root=False):
+    def getRealPathFromSegments(segments, include_virtual=True):
         """
         Return the real path for the segments.
 
-        If `no_virtual_root` is True, it will return VIRTUAL_ROOT if segments
-        are for the root of virtual folder.
+        Raises and error when `include_virtual` is False and the segments
+        are for a real path.
         """
 
     def getSegmentsFromRealPath(real_path):

--- a/chevah/compat/interfaces.py
+++ b/chevah/compat/interfaces.py
@@ -4,6 +4,7 @@
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
+from __future__ import unicode_literals
 
 from zope.interface import Interface, Attribute
 
@@ -141,9 +142,9 @@ class IFileSystemAvatar(IHasImpersonatedAvatar):
     home_folder_path = Attribute(u'Path to home folder')
     root_folder_path = Attribute(u'Path to root folder')
     lock_in_home_folder = Attribute(
-        '''
-        True if filesystem access should be limited to home folder.
-        ''')
+        'True if filesystem access should be limited to home folder.')
+    virtual_folders = Attribute(
+        'List of tuples which map segments to real paths.')
 
 
 class IOSUsers(Interface):
@@ -377,9 +378,12 @@ class ILocalFilesystem(Interface):
     home_segments = Attribute('Segments for user home folder.')
     temp_segments = Attribute('Segments to temp folder.')
 
-    def getRealPathFromSegments(segments):
+    def getRealPathFromSegments(segments, no_virtual_root=False):
         """
         Return the real path for the segments.
+
+        If `no_virtual_root` is True, it will return None if segments are
+        for the root of virtual folder.
         """
 
     def getSegmentsFromRealPath(real_path):

--- a/chevah/compat/nt_filesystem.py
+++ b/chevah/compat/nt_filesystem.py
@@ -395,7 +395,8 @@ class NTFilesystem(PosixFilesystemBase):
 
         target_path = self.getRealPathFromSegments(
             target_segments, include_virtual=False)
-        link_path = self.getRealPathFromSegments(link_segments)
+        link_path = self.getRealPathFromSegments(
+            link_segments, include_virtual=False)
 
         if self.isFolder(target_segments) or target_path.startswith('\\'):
             # We have folder or a Windows share as target.

--- a/chevah/compat/nt_filesystem.py
+++ b/chevah/compat/nt_filesystem.py
@@ -86,10 +86,6 @@ class NTFilesystem(PosixFilesystemBase):
     OPEN_READ_WRITE = os.O_RDWR | os.O_BINARY
     OPEN_APPEND = os.O_APPEND | os.O_BINARY
 
-    def __init__(self, avatar=None):
-        self._avatar = avatar
-        self._root_path = self._getRootPath()
-
     @property
     def _lock_in_home(self):
         """
@@ -245,17 +241,17 @@ class NTFilesystem(PosixFilesystemBase):
         if path is None or path == u'':
             return segments
 
-        target = os.path.abspath(path.replace('/', '\\'))
+        target = os.path.abspath(path.replace('/', '\\')).lower()
         for virtual_segments, real_path in self._avatar.virtual_folders:
-            real_path = real_path.replace('/', '\\')
+            real_path = real_path.replace('/', '\\').lower()
             virtual_root = os.path.abspath(real_path)
             if not target.startswith(virtual_root):
                 # Not a virtual folder.
                 continue
 
-            ancenstors = target[len(real_path):].split('\\')
-            ancenstors = [a for a in ancenstors if a]
-            return virtual_segments + ancenstors
+            ancestors = target[len(real_path):].split('\\')
+            ancestors = [a for a in ancestors if a]
+            return virtual_segments + ancestors
 
         head = True
 

--- a/chevah/compat/nt_filesystem.py
+++ b/chevah/compat/nt_filesystem.py
@@ -156,7 +156,7 @@ class NTFilesystem(PosixFilesystemBase):
         else:
             return self._root_path
 
-    def getRealPathFromSegments(self, segments):
+    def getRealPathFromSegments(self, segments, no_virtual_root=False):
         '''See `ILocalFilesystem`.
         * []
           * lock : root_path

--- a/chevah/compat/nt_filesystem.py
+++ b/chevah/compat/nt_filesystem.py
@@ -170,9 +170,6 @@ class NTFilesystem(PosixFilesystemBase):
           * [UNC, server1, path1, path2] -> \\server1\path1\path2
         '''
         def get_path(segments):
-            if segments is None or len(segments) == 0:
-                return self._root_path
-
             if self._lock_in_home:
                 return self._getLockedPathFromSegments(segments)
 
@@ -196,9 +193,14 @@ class NTFilesystem(PosixFilesystemBase):
                             result = result.replace('\\', ':\\', 1)
             return result
 
+        if segments is None or len(segments) == 0:
+            # We have the root path for sure.
+            return self._root_path
+
         virtual_path = self._getVirtualPathFromSegments(
             segments, no_virtual_root)
         if virtual_path is self._VIRTUAL_ROOT:
+            # We have the marker for a virtual root.
             return virtual_path
 
         if virtual_path is not None:

--- a/chevah/compat/nt_users.py
+++ b/chevah/compat/nt_users.py
@@ -373,6 +373,7 @@ class NTDefaultAvatar(NTHasImpersonatedAvatar):
     lock_in_home_folder = False
     token = None
     peer = None
+    virtual_folders = ()
 
     @property
     def use_impersonation(self):

--- a/chevah/compat/posix_filesystem.py
+++ b/chevah/compat/posix_filesystem.py
@@ -225,8 +225,11 @@ class PosixFilesystemBase(object):
                 if not os.path.lexists(self.getEncodedPath(inside_path)):
                     target_segments.pop()
                     continue
+                virtual_path = '/' + '/'.join(virtual_segments)
                 raise CompatError(
-                    1005, 'Virtual path overlaps an existing file or folder.')
+                    1005,
+                    'Virtual path "%s" overlaps an existing file or '
+                    'folder at "%s".' % (virtual_path, inside_path,))
 
     def _getVirtualPathFromSegments(self, segments, include_virtual):
         """

--- a/chevah/compat/posix_filesystem.py
+++ b/chevah/compat/posix_filesystem.py
@@ -202,7 +202,8 @@ class PosixFilesystemBase(object):
         if first == second:
             return True
 
-        if os.name == 'posix':
+        from chevah.compat import process_capabilities
+        if process_capabilities.os_name not in ['windows', 'osx']:
             # On Linux and Unix we do strict case.
             return False
 
@@ -321,7 +322,7 @@ class PosixFilesystemBase(object):
             if segments_length > len(virtual_segments):
                 # Is longer than the virtual path so it can't be part of the
                 # full virtual path.
-                continue
+                return False
 
             # This is a virtual path which has a mapping.
             return True

--- a/chevah/compat/posix_filesystem.py
+++ b/chevah/compat/posix_filesystem.py
@@ -7,8 +7,8 @@ Windows has its layer of POSIX compatibility.
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from six import text_type
 from contextlib import contextmanager
+from datetime import date
 import codecs
 import errno
 import os
@@ -18,7 +18,9 @@ import shutil
 import stat
 import struct
 import sys
+import time
 import unicodedata
+
 
 try:
     # On some systems (AIX/Windows) the public scandir module will fail to
@@ -27,6 +29,7 @@ try:
 except ImportError:
     from scandir import scandir_python as scandir
 
+from six import text_type
 from zope.interface import implements
 
 from chevah.compat.constants import (
@@ -781,6 +784,17 @@ class PosixFilesystemBase(object):
         Return the attributes which can be used for the case when a real
         attribute don't exists for `segments`.
         """
+        modified = time.mktime((
+            date.today().year,
+            1,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            -1,
+            ))
         return FileAttributes(
             name=segments[-1],
             path=self.getRealPathFromSegments(segments),
@@ -788,7 +802,7 @@ class PosixFilesystemBase(object):
             is_file=False,
             is_folder=True,
             is_link=False,
-            modified=1,
+            modified=modified,
             mode=0,
             hardlinks=1,
             uid=1,
@@ -800,8 +814,20 @@ class PosixFilesystemBase(object):
         """
         Return a placeholder status result.
         """
+        modified = time.mktime((
+            date.today().year,
+            1,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            -1,
+            ))
+
         return os.stat_result([
-            0o40555, 0, 0, 0, 1, 1, 0, 1, 1, 1])
+            0o40555, 0, 0, 0, 1, 1, 0, 1, modified, 0])
 
     def setAttributes(self, segments, attributes):
         '''See `ILocalFilesystem`.'''

--- a/chevah/compat/posix_filesystem.py
+++ b/chevah/compat/posix_filesystem.py
@@ -233,6 +233,9 @@ class PosixFilesystemBase(object):
         """
         Return True if segments are a part or full virtual folder.
         """
+        if not segments:
+            return False
+
         # Part of virtual paths, virtually exists.
         segments_length = len(segments)
         for virtual_segments, real_path in self._avatar.virtual_folders:

--- a/chevah/compat/testing/assertion.py
+++ b/chevah/compat/testing/assertion.py
@@ -99,7 +99,7 @@ class AssertionMixin(object):
                     first, second)
             raise AssertionError(msg.encode('utf-8'))
 
-    def assertIteratorEqual(self, expected, actual):
+    def assertIteratorItemsEqual(self, expected, actual):
         """
         Check that once fully iterated the `actual` iterator will return the
         `expected` list.
@@ -112,7 +112,7 @@ class AssertionMixin(object):
                 raise AssertionError('Value is not iterable.')
             except StopIteration:
                 break
-        self.assertEqual(expected, actual_list)
+        self.assertItemsEqual(expected, actual_list)
 
     def assertCompatError(self, expected_id, actual_error):
         """

--- a/chevah/compat/testing/conditionals.py
+++ b/chevah/compat/testing/conditionals.py
@@ -42,7 +42,9 @@ def skipOnCondition(callback, message):
             result.__unittest_skip__ = True
             result.__unittest_skip_why__ = message
         else:
-            result.__unittest_skip__ = False
+            already_skipped = getattr(result, '__unittest_skip__', False)
+            if not already_skipped:
+                result.__unittest_skip__ = False
 
         return result
 

--- a/chevah/compat/testing/conditionals.py
+++ b/chevah/compat/testing/conditionals.py
@@ -42,7 +42,7 @@ def skipOnCondition(callback, message):
             result.__unittest_skip__ = True
             result.__unittest_skip_why__ = message
         else:
-            result.__unittest_skip__ = True
+            result.__unittest_skip__ = False
 
         return result
 

--- a/chevah/compat/testing/testcase.py
+++ b/chevah/compat/testing/testcase.py
@@ -1080,10 +1080,10 @@ class ChevahTestCase(TwistedTestCase, AssertionMixin):
     def cleanWorkingFolder(cls):
         path = mk.fs.getAbsoluteRealPath('.')
         segments = mk.fs.getSegmentsFromRealPath(path)
-        return cls._cleanFolder(segments)
+        return cls._cleanFolder(segments, only_marked=True)
 
     @classmethod
-    def _cleanFolder(cls, folder_segments):
+    def _cleanFolder(cls, folder_segments, only_marked=False):
         """
         Clean all test files from folder_segments.
 
@@ -1102,14 +1102,15 @@ class ChevahTestCase(TwistedTestCase, AssertionMixin):
         temp_filesystem = LocalFilesystem(avatar=temp_avatar)
         temp_members = []
         for member in (temp_filesystem.getFolderContent(folder_segments)):
-            if member.find(TEST_NAME_MARKER) != -1:
-                temp_members.append(member)
-                segments = folder_segments[:]
-                segments.append(member)
-                if temp_filesystem.isFolder(segments):
-                    temp_filesystem.deleteFolder(segments, recursive=True)
-                else:
-                    temp_filesystem.deleteFile(segments)
+            if only_marked and member.find(TEST_NAME_MARKER) == -1:
+                continue
+            temp_members.append(member)
+            segments = folder_segments[:]
+            segments.append(member)
+            if temp_filesystem.isFolder(segments):
+                temp_filesystem.deleteFolder(segments, recursive=True)
+            else:
+                temp_filesystem.deleteFile(segments)
 
         return temp_members
 

--- a/chevah/compat/tests/normal/test_avatar.py
+++ b/chevah/compat/tests/normal/test_avatar.py
@@ -7,13 +7,14 @@ from __future__ import with_statement
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
+from __future__ import unicode_literals
 
 from chevah.compat.avatar import FilesystemAvatar
 from chevah.compat.interfaces import IFileSystemAvatar
 from chevah.compat.testing import ChevahTestCase, mk
 
 
-class TestAvatarBase(ChevahTestCase):
+class TestFilesystemAvatar(ChevahTestCase):
 
     def test_init_no_arguments(self):
         """
@@ -56,20 +57,41 @@ class TestAvatarBase(ChevahTestCase):
         self.assertEqual(mk.fs.temp_path, avatar.home_folder_path)
         self.assertEqual(name, avatar.name)
         self.assertIsNone(avatar.root_folder_path)
+        self.assertEqual((), avatar.virtual_folders)
 
     def test_init_all_arguments(self):
         """
-        Avatar can also be initialized with a root path.
+        Avatar can also be initialized with argument and the exported
+        attributes are read only.
         """
         avatar = FilesystemAvatar(
             name=mk.getUniqueString(),
             home_folder_path=u'some-path',
             root_folder_path=u'other-path',
             token=u'the-token',
+            virtual_folders=(
+                (['base', 'segment'], '/some/real/path'),
+                (['other', 'segment'], 'c:\\other\\path'),
+                )
             )
 
         self.assertEqual(u'other-path', avatar.root_folder_path)
+        with self.assertRaises(AttributeError):
+            avatar.root_folder_path = 'something'
+
         self.assertEqual(u'the-token', avatar.token)
+        with self.assertRaises(AttributeError):
+            avatar.token = 'something'
+
+        self.assertEqual(
+            (
+                (['base', 'segment'], '/some/real/path'),
+                (['other', 'segment'], 'c:\\other\\path'),
+                ),
+            avatar.virtual_folders,
+            )
+        with self.assertRaises(AttributeError):
+            avatar.virtual_folders = 'something'
 
 
 class TestApplicationAvatar(ChevahTestCase):

--- a/chevah/compat/tests/normal/test_filesystem.py
+++ b/chevah/compat/tests/normal/test_filesystem.py
@@ -6,6 +6,7 @@ Tests for portable filesystem access.
 from __future__ import absolute_import, division, unicode_literals
 from six import text_type
 
+from datetime import date
 import errno
 import os
 import platform
@@ -22,6 +23,18 @@ from chevah.compat.avatar import FilesystemApplicationAvatar
 from chevah.compat.exceptions import CompatError
 from chevah.compat.interfaces import IFileAttributes, ILocalFilesystem
 from chevah.compat.testing import CompatTestCase, conditionals, mk
+
+start_of_year = time.mktime((
+    date.today().year,
+    1,
+    1,
+    0,
+    0,
+    0,
+    0,
+    0,
+    -1,
+    ))
 
 
 class FilesystemTestingHelpers(object):
@@ -3275,6 +3288,7 @@ class TestLocalFilesystemVirtualFolder(CompatTestCase):
         self.assertEqual(
             os.path.join(mk.fs.temp_path, 'some\N{cloud}'), result.path)
         self.assertEqual(0, result.size)
+        self.assertEqual(start_of_year, result.modified)
 
         result = sut.getAttributes([])
         self.assertTrue(result.is_folder)
@@ -3369,6 +3383,8 @@ class TestLocalFilesystemVirtualFolder(CompatTestCase):
         self.assertTrue(stat.S_ISDIR(result.st_mode))
         self.assertFalse(stat.S_ISLNK(result.st_mode))
         self.assertEqual(0, result.st_ino)
+        self.assertEqual(start_of_year, result.st_mtime)
+        self.assertEqual(1, result.st_atime)
 
         result = sut.getStatus([])
         self.assertFalse(stat.S_ISREG(result.st_mode))

--- a/chevah/compat/tests/normal/test_filesystem.py
+++ b/chevah/compat/tests/normal/test_filesystem.py
@@ -2654,7 +2654,7 @@ class TestLocalFilesystemVirtualFolder(CompatTestCase):
         Tests with NT paths.
         """
         sut = self.getFilesystem(virtual_folders=[
-            (['some\N{sun}', 'base\N{sun}'], 'c:/someN{sun}/path'),
+            (['some\N{sun}', 'base\N{sun}'], 'c:/some\N{sun}/path'),
             (['base\N{sun}'], 'e:\\otherN{leo}\\path'),
             ])
 
@@ -3247,6 +3247,7 @@ class TestLocalFilesystemVirtualFolder(CompatTestCase):
             sut.readLink(
                 ['virtual-\N{cloud}', 'base\N{sun}', 'non-existent-file'])
 
+    @conditionals.onCapability('symbolic_link', True)
     def test_makeLink_virtual(self):
         """
         It can't create links to or from virtual paths.

--- a/chevah/compat/tests/normal/test_filesystem.py
+++ b/chevah/compat/tests/normal/test_filesystem.py
@@ -2616,12 +2616,12 @@ class TestLocalFilesystemVirtualFolder(CompatTestCase):
         """
         sut = self.getFilesystem(virtual_folders=[
             (['some', 'base'], '/some/path'),
-            (['base'], '/other/path'),
+            (['base\N{leo}'], '/other\N{sun}/path'),
             ])
 
-        result = sut.getRealPathFromSegments(['base'])
+        result = sut.getRealPathFromSegments(['base\N{leo}'])
 
-        self.assertEqual('/other/path', result)
+        self.assertEqual('/other\N{sun}/path', result)
 
     @conditionals.onOSFamily('nt')
     def test_getRealPathFromSegments_match_nt(self):
@@ -2632,16 +2632,16 @@ class TestLocalFilesystemVirtualFolder(CompatTestCase):
         Tests with NT paths.
         """
         sut = self.getFilesystem(virtual_folders=[
-            (['some', 'base'], 'c:/some/path'),
-            (['base'], 'e:\\other\\path'),
+            (['some\N{sun}', 'base\N{sun}'], 'c:/someN{sun}/path'),
+            (['base\N{sun}'], 'e:\\otherN{leo}\\path'),
             ])
 
-        result = sut.getRealPathFromSegments(['base'])
-        self.assertEqual('e:\\other\\path', result)
+        result = sut.getRealPathFromSegments(['base\N{sun}'])
+        self.assertEqual('e:\\otherN{leo}\\path', result)
 
         # It will normalize the path.
-        result = sut.getRealPathFromSegments(['some', 'base'])
-        self.assertEqual('c:\\some\\path', result)
+        result = sut.getRealPathFromSegments(['some\N{sun}', 'base\N{sun}'])
+        self.assertEqual('c:\\some\N{sun}\\path', result)
 
     def test_getRealPathFromSegments_match_no_root(self):
         """
@@ -2649,16 +2649,17 @@ class TestLocalFilesystemVirtualFolder(CompatTestCase):
         folder and were asked to not return virtual roots.
         """
         sut = self.getFilesystem(virtual_folders=[
-            (['some', 'base'], '/some/path'),
-            (['base'], '/other/path'),
+            (['some\N{sun}', 'base\N{sun}'], '/some/path'),
+            (['base\N{sun}'], '/other/path'),
             ])
 
-        result = sut.getRealPathFromSegments(['base'], no_virtual_root=True)
+        result = sut.getRealPathFromSegments(
+            ['base\N{sun}'], no_virtual_root=True)
 
         self.assertIs(sut._VIRTUAL_ROOT, result)
 
         result = sut.getRealPathFromSegments(
-            ['some', 'base'], no_virtual_root=True)
+            ['some\N{sun}', 'base\N{sun}'], no_virtual_root=True)
 
         self.assertIs(sut._VIRTUAL_ROOT, result)
 
@@ -2671,13 +2672,13 @@ class TestLocalFilesystemVirtualFolder(CompatTestCase):
         Test with Posix paths.
         """
         sut = self.getFilesystem(virtual_folders=[
-            (['some', 'base'], '/some/path'),
-            (['base'], '/other/path'),
+            (['some', 'base'], '/some/path\N{sun}'),
+            (['base\N{sun}'], '/other/path\N{sun}'),
             ])
 
-        result = sut.getRealPathFromSegments(['base', 'child'])
+        result = sut.getRealPathFromSegments(['base\N{sun}', 'child\N{cloud}'])
 
-        self.assertEqual('/other/path/child', result)
+        self.assertEqual('/other/path\N{sun}/child\N{cloud}', result)
 
     @conditionals.onOSFamily('nt')
     def test_getRealPathFromSegments_child_match_nt(self):
@@ -2686,15 +2687,16 @@ class TestLocalFilesystemVirtualFolder(CompatTestCase):
         segments.
         """
         sut = self.getFilesystem(virtual_folders=[
-            (['some', 'base'], 'c:/some/path'),
-            (['base'], 'e:\\other\\path'),
+            (['some', 'base\N{sun}'], 'c:/some/path\N{sun}'),
+            (['base\N{sun}'], 'e:\\other\N{sun}\\path'),
             ])
 
-        result = sut.getRealPathFromSegments(['base', 'child'])
-        self.assertEqual('e:\\other\\path\\child', result)
+        result = sut.getRealPathFromSegments(['base\N{sun}', 'child\N{cloud}'])
+        self.assertEqual('e:\\other\N{sun}\\path\\child\N{cloud}', result)
 
-        result = sut.getRealPathFromSegments(['some', 'base', 'child'])
-        self.assertEqual('c:\\some\\path\\child', result)
+        result = sut.getRealPathFromSegments(
+            ['some', 'base\N{sun}', 'child\N{sun}'])
+        self.assertEqual('c:\\some\\path\N{sun}\\child\N{sun}', result)
 
     def test_getSegmentsFromRealPath_no_match(self):
         """
@@ -2728,27 +2730,27 @@ class TestLocalFilesystemVirtualFolder(CompatTestCase):
         Tests with posix paths. Keep in sync with NT paths.
         """
         sut = self.getFilesystem(virtual_folders=[
-            (['some', 'base'], '/virtual/path/'),
-            (['base'], '/other/path'),
+            (['some\N{sun}', 'base'], '/virtual/path\N{sun}/'),
+            (['base\N{sun}'], '/other\N{sun}/path'),
             ])
 
-        result = sut.getSegmentsFromRealPath('/virtual/path')
-        self.assertEqual(['some', 'base'], result)
+        result = sut.getSegmentsFromRealPath('/virtual/path\N{sun}')
+        self.assertEqual(['some\N{sun}', 'base'], result)
 
-        result = sut.getSegmentsFromRealPath('/virtual/path/')
-        self.assertEqual(['some', 'base'], result)
+        result = sut.getSegmentsFromRealPath('/virtual/path\N{sun}/')
+        self.assertEqual(['some\N{sun}', 'base'], result)
 
-        result = sut.getSegmentsFromRealPath('/virtual/path//')
-        self.assertEqual(['some', 'base'], result)
+        result = sut.getSegmentsFromRealPath('/virtual/path\N{sun}//')
+        self.assertEqual(['some\N{sun}', 'base'], result)
 
-        result = sut.getSegmentsFromRealPath('/other/../virtual/path//')
-        self.assertEqual(['some', 'base'], result)
+        result = sut.getSegmentsFromRealPath('/other/../virtual/path\N{sun}//')
+        self.assertEqual(['some\N{sun}', 'base'], result)
 
-        result = sut.getSegmentsFromRealPath('/other/path')
-        self.assertEqual(['base'], result)
+        result = sut.getSegmentsFromRealPath('/other\N{sun}/path')
+        self.assertEqual(['base\N{sun}'], result)
 
-        result = sut.getSegmentsFromRealPath('/other/path/')
-        self.assertEqual(['base'], result)
+        result = sut.getSegmentsFromRealPath('/other\N{sun}/path/')
+        self.assertEqual(['base\N{sun}'], result)
 
     @conditionals.onOSFamily('nt')
     def test_getSegmentsFromRealPath_match_nt(self):
@@ -2842,6 +2844,50 @@ class TestLocalFilesystemVirtualFolder(CompatTestCase):
         with self.assertRaises(CompatError) as context:
             sut.deleteFolder(['some', 'base'])
 
+        self.assertEqual(1010, context.exception.event_id)
+
+        # When only a partial match is done, it will try to delete the
+        # real path.
+        with self.assertRaises(OSError) as context:
+            sut.deleteFolder(['some'])
+
+    def test_createFolder_virtual(self):
+        """
+        You can't create a folder over a virtual path.
+        """
+        sut = self.getFilesystem(virtual_folders=[
+            (['virtual-\N{cloud}', 'base\N{sun}'], mk.fs.temp_path)
+            ])
+
+        # It can create outside of the virtual folders.
+        sut.createFolder(['new\N{cloud}'])
+        self.addCleanup(sut.deleteFolder, ['new\N{cloud}'])
+        result = sut.getFolderContent([])
+        self.assertItemsEqual(['new\N{cloud}', 'virtual-\N{cloud}'], result)
+
+        # It can create folders over the virtual ones.
+        with self.assertRaises(CompatError) as context:
+            sut.createFolder(['virtual-\N{cloud}'])
+        self.assertEqual(1010, context.exception.event_id)
+
+        with self.assertRaises(CompatError) as context:
+            sut.createFolder(['virtual-\N{cloud}', 'base\N{sun}'])
+        self.assertEqual(1010, context.exception.event_id)
+
+    def test_touch_virtual(self):
+        """
+        It can't touch a virtual root.
+        """
+        sut = self.getFilesystem(virtual_folders=[
+            (['virtual-\N{cloud}', 'base\N{sun}'], mk.fs.temp_path)
+            ])
+
+        with self.assertRaises(CompatError) as context:
+            sut.touch(['virtual-\N{cloud}'])
+        self.assertEqual(1010, context.exception.event_id)
+
+        with self.assertRaises(CompatError) as context:
+            sut.touch(['virtual-\N{cloud}', 'base\N{sun}'])
         self.assertEqual(1010, context.exception.event_id)
 
     def test_setOwner_virtual(self):
@@ -2984,74 +3030,108 @@ class TestLocalFilesystemVirtualFolder(CompatTestCase):
         """
         virtual_path, virtual_segments = self.tempFolder('virtual')
         mk.fs.createFolder(virtual_segments + ['child-folder'])
-        mk.fs.createFile(virtual_segments + ['child-file'])
+        mk.fs.createFile(virtual_segments + ['child-file\N{sun}'])
 
         sut = self.getFilesystem(virtual_folders=[
-            (['base'], virtual_path)
+            (['base\N{sun}'], virtual_path)
             ])
 
-        result = sut.getFolderContent(['base'])
+        result = sut.getFolderContent(['base\N{sun}'])
 
-        self.assertItemsEqual(['child-folder', 'child-file'], result)
+        self.assertItemsEqual(['child-folder', 'child-file\N{sun}'], result)
 
     @conditionals.skipOnPY3()
     def test_getFolderContent_virtual_member(self):
         """
         It can list a virtual folder as member of a parent folder.
         """
-        virtual_path, virtual_segments = self.tempFolder('virtual')
-        self.tempFolder('non-virtual')
-        mk.fs.createFolder(virtual_segments + ['child-folder'])
+        virtual_path, virtual_segments = self.tempFolder('other-real\N{sun}')
+        self.tempFolder('non-virtual\N{sun}')
+        mk.fs.createFolder(virtual_segments + ['child-folder\N{sun}'])
         mk.fs.createFile(virtual_segments + ['child-file'])
 
         sut = self.getFilesystem(virtual_folders=[
-            (['base'], virtual_path)
+            (['\N{sun}base'], virtual_path)
             ])
 
+        expected = ['\N{sun}base', 'non-virtual\N{sun}', 'other-real\N{sun}']
         result = sut.getFolderContent([])
-
-        expected = ['base', 'non-virtual', 'virtual']
         self.assertItemsEqual(expected, result)
 
         result = sut.iterateFolderContent([])
         self.assertIteratorItemsEqual(expected, result)
 
+    @conditionals.skipOnPY3()
+    def test_getFolderContent_virtual_singe_root(self):
+        """
+        It will not list the member multiple time if they overlay with
+        virtual segments.
+        """
+        self.tempFolder('other-real\N{sun}')
+
+        sut = self.getFilesystem(virtual_folders=[
+            (['other-real\N{sun}', 'base1'], mk.fs.temp_path),
+            (['other-real\N{sun}', 'base2'], mk.fs.temp_path)
+            ])
+
+        expected = ['other-real\N{sun}']
+        result = sut.getFolderContent([])
+        self.assertItemsEqual(expected, result)
+
+        result = sut.iterateFolderContent([])
+        self.assertIteratorItemsEqual(expected, result)
+
+    @conditionals.skipOnPY3()
     def test_getFolderContent_virtual_no_match(self):
         """
         It will ignore the virtual folders if they don't overlay to the
         requested folder..
         """
-        _, segments = self.tempFolder('non-virtual')
+        _, segments = self.tempFolder('non-virtual\N{sun}')
         mk.fs.createFolder(segments + ['child-folder'])
-        mk.fs.createFile(segments + ['child-file'])
+        mk.fs.createFile(segments + ['child-file\N{sun}'])
 
         sut = self.getFilesystem(virtual_folders=[
             (['virtual', 'child-virtual'], mk.fs.temp_path),
             (['virtual', 'deep-virtual', 'other'], mk.fs.temp_path),
             ])
 
-        result = sut.getFolderContent(['non-virtual'])
+        expected = ['child-folder', 'child-file\N{sun}']
 
-        self.assertItemsEqual(['child-folder', 'child-file'], result)
+        result = sut.getFolderContent(['non-virtual\N{sun}'])
+        self.assertItemsEqual(expected, result)
 
+        result = sut.iterateFolderContent(['non-virtual\N{sun}'])
+        self.assertIteratorItemsEqual(expected, result)
+
+    @conditionals.skipOnPY3()
     def test_getFolderContent_virtual_mix(self):
         """
         It can list a virtual folder as member of a parent folder mixed
         with non-virtual members.
         """
-        _, segments = self.tempFolder('non-virtual')
+        _, segments = self.tempFolder('non-virtual\N{sun}')
         mk.fs.createFolder(segments + ['child-folder'])
         mk.fs.createFile(segments + ['child-file'])
 
         sut = self.getFilesystem(virtual_folders=[
-            (['non-virtual', 'virtual'], mk.fs.temp_path),
-            (['non-virtual', 'deep-virtual', 'other'], mk.fs.temp_path),
+            (['non-virtual\N{sun}', 'virtual\N{cloud}'], mk.fs.temp_path),
+            (['non-virtual\N{sun}', 'child-file', 'other'], mk.fs.temp_path),
             ])
 
-        result = sut.getFolderContent(['non-virtual'])
+        expected = ['child-folder', 'child-file', 'virtual\N{cloud}']
 
-        self.assertItemsEqual(
-            ['child-folder', 'child-file', 'virtual', 'deep-virtual'], result)
+        result = sut.getFolderContent(['non-virtual\N{sun}'])
+        self.assertItemsEqual(expected, result)
+
+        result = sut.iterateFolderContent(['non-virtual\N{sun}'])
+        self.assertIteratorItemsEqual(expected, result)
+
+        result = sut.getFolderContent([])
+        self.assertEqual(['non-virtual\N{sun}'], result)
+
+        result = sut.iterateFolderContent([])
+        self.assertIteratorItemsEqual(['non-virtual\N{sun}'], result)
 
 
 class TestFileAttributes(CompatTestCase):

--- a/chevah/compat/tests/normal/test_filesystem.py
+++ b/chevah/compat/tests/normal/test_filesystem.py
@@ -2518,6 +2518,7 @@ class TestLocalFilesystemLocked(CompatTestCase, FilesystemTestMixin):
 
 
 @conditionals.onOSFamily('nt')
+@conditionals.onCapability('symbolic_link', True)
 class TestLocalFilesystemLockedUNC(CompatTestCase, FilesystemTestMixin):
     """
     Tests for locked filesystem with UNC path.
@@ -2993,6 +2994,7 @@ class TestLocalFilesystemVirtualFolder(CompatTestCase):
 
         self.assertItemsEqual(['child-folder', 'child-file'], result)
 
+    @conditionals.skipOnPY3()
     def test_getFolderContent_virtual_member(self):
         """
         It can list a virtual folder as member of a parent folder.

--- a/chevah/compat/tests/normal/test_filesystem.py
+++ b/chevah/compat/tests/normal/test_filesystem.py
@@ -2617,6 +2617,10 @@ class TestLocalFilesystemVirtualFolder(CompatTestCase):
                 (segments[-1:], mk.fs.temp_path),
                 ])
         self.assertEqual(1005, context.exception.event_id)
+        self.assertEqual(
+            'Virtual path "/%s" overlaps an existing file or '
+            'folder at "%s".' % (segments[-1], path),
+            context.exception.message)
 
         # But also if a parent of the virtual path exists.
         with self.assertRaises(CompatError) as context:

--- a/chevah/compat/tests/normal/test_filesystem.py
+++ b/chevah/compat/tests/normal/test_filesystem.py
@@ -1046,7 +1046,7 @@ class TestLocalFilesystem(DefaultFilesystemTestCase):
             # and the slave is generally slow.
             count = 32000
             base_timeout = 0.15
-        elif self.cpu_type == 'sparc':
+        elif self.cpu_type in ['sparc', 'arm64']:
             count = 5000
             base_timeout = 0.1
         else:

--- a/chevah/compat/tests/normal/test_filesystem.py
+++ b/chevah/compat/tests/normal/test_filesystem.py
@@ -972,7 +972,7 @@ class TestLocalFilesystem(DefaultFilesystemTestCase):
 
         result = self.filesystem.iterateFolderContent(segments)
 
-        self.assertIteratorEqual([], result)
+        self.assertIteratorItemsEqual([], result)
 
     @conditionals.skipOnPY3()
     def test_iterateFolderContent_non_empty(self):
@@ -3008,11 +3008,11 @@ class TestLocalFilesystemVirtualFolder(CompatTestCase):
 
         result = sut.getFolderContent([])
 
-        expected = ['non-virtual', 'base', 'virtual']
+        expected = ['base', 'non-virtual', 'virtual']
         self.assertItemsEqual(expected, result)
 
         result = sut.iterateFolderContent([])
-        self.assertIteratorEqual(expected, result)
+        self.assertIteratorItemsEqual(expected, result)
 
     def test_getFolderContent_virtual_no_match(self):
         """

--- a/chevah/compat/tests/normal/testing/test_assertion.py
+++ b/chevah/compat/tests/normal/testing/test_assertion.py
@@ -139,7 +139,7 @@ class TestAssertionMixin(ChevahTestCase):
             exception.args[0],
             )
 
-    def test_assertIteratorEqual_no_iterable(self):
+    def test_assertIteratorItemsEqual_no_iterable(self):
         """
         Raise an exception if the actual value is not iterable.
         """
@@ -147,7 +147,7 @@ class TestAssertionMixin(ChevahTestCase):
 
         exception = self.assertRaises(
             AssertionError,
-            self.assertIteratorEqual,
+            self.assertIteratorItemsEqual,
             [],
             sut,
             )
@@ -157,25 +157,26 @@ class TestAssertionMixin(ChevahTestCase):
             exception.args[0],
             )
 
-    def test_assertIteratorEqual_ok(self):
+    def test_assertIteratorItemsEqual_ok(self):
         """
-        All file is iterator is equal.
+        Is equal even if elements are in a different order.
         """
-        value = [1, b'3', u'a', iter([2])]
+        iterator = iter([2])
+        value = [1, b'3', u'a', iterator]
         sut = iter(value)
 
-        self.assertIteratorEqual(value, sut)
+        self.assertIteratorItemsEqual([b'3', 1, u'a', iterator], sut)
 
-    def test_assertIteratorEqual_less(self):
+    def test_assertIteratorItemsEqual_less(self):
         """
-        All file is iterator is equal.
+        It fails if the values are not equal.
         """
         value = [1, b'3', u'a']
         sut = iter(value)
 
         exception = self.assertRaises(
             AssertionError,
-            self.assertIteratorEqual,
+            self.assertIteratorItemsEqual,
             [1],
             sut,
             )
@@ -183,6 +184,6 @@ class TestAssertionMixin(ChevahTestCase):
         # The check here is more complicated since the message relies on the
         # assertEqual implementation.
         self.assertStartsWith(
-            "Lists differ: [1] != [1, '3', u'a']",
+            "Element counts were not equal:",
             exception.args[0],
             )

--- a/chevah/compat/tests/normal/testing/test_testcase.py
+++ b/chevah/compat/tests/normal/testing/test_testcase.py
@@ -306,7 +306,7 @@ class TestTwistedTestCase(ChevahTestCase):
         self.executeReactor()
         # Allow the thread to settle and return.
         time.sleep(0.01)
-        time.sleep(0.04)
+        time.sleep(0.05)
         self.assertTrue(self.called)
         self.assertTrue(deferred.called)
 

--- a/chevah/compat/tests/normal/testing/test_testcase.py
+++ b/chevah/compat/tests/normal/testing/test_testcase.py
@@ -298,7 +298,7 @@ class TestTwistedTestCase(ChevahTestCase):
         self.called = False
 
         def last_call():
-            time.sleep(0.2)
+            time.sleep(0.5)
             self.called = True
 
         deferred = threads.deferToThread(last_call)

--- a/chevah/compat/unix_filesystem.py
+++ b/chevah/compat/unix_filesystem.py
@@ -36,10 +36,6 @@ class UnixFilesystem(PosixFilesystemBase):
     implements(ILocalFilesystem)
     system_users = UnixUsers()
 
-    def __init__(self, avatar):
-        self._avatar = avatar
-        self._root_handler = self._getRootPath()
-
     def _getRootPath(self):
         if not self._avatar:
             return u'/'
@@ -57,7 +53,7 @@ class UnixFilesystem(PosixFilesystemBase):
         See `ILocalFilesystem`.
         """
         if segments is None or len(segments) == 0:
-            return text_type(self._root_handler)
+            return text_type(self._root_path)
 
         result = self._getVirtualPathFromSegments(segments, include_virtual)
         if result is not None:
@@ -65,7 +61,7 @@ class UnixFilesystem(PosixFilesystemBase):
 
         relative_path = u'/' + u'/'.join(segments)
         relative_path = os.path.abspath(relative_path).rstrip('/')
-        return text_type(self._root_handler.rstrip('/') + relative_path)
+        return text_type(self._root_path.rstrip('/') + relative_path)
 
     def getSegmentsFromRealPath(self, path):
         """
@@ -84,13 +80,13 @@ class UnixFilesystem(PosixFilesystemBase):
                 # Not a virtual folder.
                 continue
 
-            ancenstors = tail[len(real_path):].split('/')
-            ancenstors = [a for a in ancenstors if a]
-            return virtual_segments + ancenstors
+            ancestors = tail[len(real_path):].split('/')
+            ancestors = [a for a in ancestors if a]
+            return virtual_segments + ancestors
 
         if self._avatar.lock_in_home_folder:
-            self._checkChildPath(self._root_handler, tail)
-            tail = tail[len(self._root_handler):]
+            self._checkChildPath(self._root_path, tail)
+            tail = tail[len(self._root_path):]
 
         while tail and head != u'/':
             head, tail = os.path.split(tail)

--- a/chevah/compat/unix_users.py
+++ b/chevah/compat/unix_users.py
@@ -488,6 +488,7 @@ class UnixDefaultAvatar(UnixHasImpersonatedAvatar):
     lock_in_home_folder = False
     token = None
     peer = None
+    virtual_folders = ()
 
     @property
     def use_impersonation(self):
@@ -516,6 +517,7 @@ class UnixSuperAvatar(UnixHasImpersonatedAvatar):
     lock_in_home_folder = False
     token = None
     peer = None
+    virtual_folders = ()
 
     @property
     def use_impersonation(self):

--- a/pavement.py
+++ b/pavement.py
@@ -462,7 +462,7 @@ def test_ci(args):
     environment.args = args
 
     skip_coverage = False
-    if pave.os_name.startswith('alpine') or pave.os_name == 'hpux':
+    if pave.os_name.startswith('alpine') or pave.os_name.startswith('hpux'):
         # On alpine coverage reporting segfaults.
         # On HPUX we run out of memory.
         skip_coverage = True

--- a/pavement.py
+++ b/pavement.py
@@ -462,8 +462,9 @@ def test_ci(args):
     environment.args = args
 
     skip_coverage = False
-    if pave.os_name.startswith('alpine'):
+    if pave.os_name.startswith('alpine') or pave.os_name == 'hpux':
         # On alpine coverage reporting segfaults.
+        # On HPUX we run out of memory.
         skip_coverage = True
 
     if skip_coverage:

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,12 @@ Release notes for chevah.compat
 ===============================
 
 
+0.51.6 - 26/06/2018
+-------------------
+
+* Use start of current year for date of virtual folders.
+
+
 0.51.5 - 22/06/2018
 -------------------
 

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,13 @@ Release notes for chevah.compat
 ===============================
 
 
+0.50.0 - 14/06/2018
+-------------------
+
+* Add support for virtual directories as a way to allow explicit access to
+  selected folders outside of the locked root.
+
+
 0.49.3 - 08/05/2018
 -------------------
 

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -1,6 +1,13 @@
 Release notes for chevah.compat
 ===============================
 
+
+0.51.3 - 17/06/2018
+-------------------
+
+* Fix getAttributes and getStatus operations for root segments.
+
+
 0.51.2 - 16/06/2018
 -------------------
 

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -1,6 +1,14 @@
 Release notes for chevah.compat
 ===============================
 
+
+0.51.5 - 22/06/2018
+-------------------
+
+* Fix detection of virtual path for nested virtual paths.
+* Add macOS on the list of case-insensitive path handling.
+
+
 0.51.4 - 21/06/2018
 -------------------
 

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -1,6 +1,17 @@
 Release notes for chevah.compat
 ===============================
 
+0.51.4 - 21/06/2018
+-------------------
+
+* Disable the filesystem overlay functionality. You can no longer mix virtual
+  with non-virtual paths.
+* The LocalFilesystem now fails to initialized if a virtual path overlaps an
+  existing folder.
+* Operation will fail if they are executed on a path which looks like a virtual
+  path but has no direct mapping.
+* Add case insensitive behaviour for Windows.
+
 
 0.51.3 - 17/06/2018
 -------------------
@@ -27,7 +38,7 @@ Release notes for chevah.compat
 -------------------
 
 * Add support for virtual directories as a way to allow explicit access to
-  selected folders outside of the locked root.
+  selected folders outside of the locked home folder.
 * Fix skipOnCondition to run the tests when condition is meet.
 
 

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -7,6 +7,7 @@ Release notes for chevah.compat
 
 * Add support for virtual directories as a way to allow explicit access to
   selected folders outside of the locked root.
+* Fix skipOnCondition to run the tests when condition is meet.
 
 
 0.49.3 - 08/05/2018

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -1,8 +1,22 @@
 Release notes for chevah.compat
 ===============================
 
+0.51.2 - 16/06/2018
+-------------------
 
-0.50.0 - 14/06/2018
+* Restrict any mutating operation on the virtual path itself or for parts
+  of the virtual path.
+* Fix listing of deep virtual path which are not overlaid.
+
+
+0.51.1 - 15/06/2018
+-------------------
+
+* Fix listing of virtual path which are overlaid
+* Fix folder iteration with unicode.
+
+
+0.50.0 - 15/06/2018
 -------------------
 
 * Add support for virtual directories as a way to allow explicit access to

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.49.3'
+VERSION = '0.50.0'
 
 
 class PublishCommand(Command):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.50.0'
+VERSION = '0.50.2'
 
 
 class PublishCommand(Command):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.50.5'
+VERSION = '0.50.6'
 
 
 class PublishCommand(Command):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.50.3'
+VERSION = '0.50.4'
 
 
 class PublishCommand(Command):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.50.4'
+VERSION = '0.50.5'
 
 
 class PublishCommand(Command):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.50.2'
+VERSION = '0.50.3'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
Scope
=====

This adds support for creating virtual folders (virtual segments) on top of the normal available segments.

This will work like a symlink and is available for both locked and unlocked filesystems.

Changes
=======

Add support for virtual folders and error handling when trying to mutate a virtual folder.


How to try and test the changes
===============================

reviewers: @dumol 

The filesystem handling is part of chevah/compat so we have this change here... but the main tests will be done in a server dedicated PR

This PR is big as there are a lot of tests.