### PR TITLE
[#5072] Add filename to OSError.

### DIFF
--- a/chevah/compat/tests/normal/test_filesystem.py
+++ b/chevah/compat/tests/normal/test_filesystem.py
@@ -246,20 +246,41 @@ class TestLocalFilesystem(DefaultFilesystemTestCase):
         folder_name = segments[-1]
         self.assertTrue(folder_name.startswith('build-'))
 
-    def test_IOToOSError(self):
+    def test_convertToOSError_IOError(self):
         """
-        Convert IOError to OSError using a context.
+        Convert IOError to OSError using a context, and add the path if error
+        is missing the path.
         """
         path = mk.string()
         message = mk.string()
 
         with self.assertRaises(OSError) as context:
-            with self.filesystem._IOToOSError(path):
+            with self.filesystem._convertToOSError(path):
                 raise IOError(3, message)
 
         self.assertEqual(3, context.exception.errno)
-        self.assertEqual(path.encode('utf-8'), context.exception.filename)
-        self.assertEqual(message.encode('utf-8'), context.exception.strerror)
+        if self.os_family == 'posix':
+            self.assertEqual(path.encode('utf-8'), context.exception.filename)
+        else:
+            self.assertEqual(path, context.exception.filename)
+
+        self.assertEqual(message, context.exception.strerror)
+
+    def test_convertToOSError_OSError(self):
+        """
+        Keep OSError and don't add the path when the exception already has
+        a path.
+        """
+        path = mk.string()
+        message = mk.string()
+
+        with self.assertRaises(OSError) as context:
+            with self.filesystem._convertToOSError(path):
+                raise OSError(3, message, 'other-path')
+
+        self.assertEqual(3, context.exception.errno)
+        self.assertEqual('other-path', context.exception.filename)
+        self.assertEqual(message, context.exception.strerror)
 
     def test_deleteFile_folder(self):
         """

--- a/chevah/compat/tests/normal/test_filesystem.py
+++ b/chevah/compat/tests/normal/test_filesystem.py
@@ -1613,19 +1613,21 @@ class TestLocalFilesystem(DefaultFilesystemTestCase):
         """
         path, segments = mk.fs.makePathInTemp()
 
+        expected_path = path
+        if self.os_family == 'posix':
+            expected_path = path.encode('utf-8')
+
         with self.assertRaises(OSError) as context:
             self.filesystem.openFileForUpdating(segments, utf8=False)
 
         self.assertEqual(errno.ENOENT, context.exception.errno)
-        if self.os_family == 'posix':
-            # On Windows, the path is not set to the exception.
-            self.assertEqual(path.encode('utf-8'), context.exception.filename)
+        self.assertEqual(expected_path, context.exception.filename)
 
         with self.assertRaises(OSError) as context:
             self.filesystem.openFileForUpdating(segments, utf8=True)
 
         self.assertEqual(errno.ENOENT, context.exception.errno)
-        self.assertEqual(path.encode('utf-8'), context.exception.filename)
+        self.assertEqual(expected_path, context.exception.filename)
 
     def test_openFileForUpdating_existing_binary(self):
         """

--- a/pavement.py
+++ b/pavement.py
@@ -108,6 +108,7 @@ TEST_PACKAGES = [
     'nose-randomly==1.2.5',
     'mock',
 
+    'coverator==0.1.4',
     'coverage==4.4.1',
 
     # used for remote debugging.

--- a/paver.conf
+++ b/paver.conf
@@ -1,4 +1,4 @@
 BASE_REQUIREMENTS='chevah-brink==0.70.3 paver==1.2.4'
-PYTHON_CONFIGURATION='default@2.7.15.db9bad48:solaris10@2.7.8.db9bad48'
+PYTHON_CONFIGURATION='default@2.7.15.1afde4e1:solaris10@2.7.8.1afde4e1'
 BINARY_DIST_URI='http://binary.chevah.com/production'
 PIP_INDEX='http://pypi.chevah.com'

--- a/paver.conf
+++ b/paver.conf
@@ -1,4 +1,4 @@
-BASE_REQUIREMENTS='chevah-brink==0.69.1 paver==1.2.4'
+BASE_REQUIREMENTS='chevah-brink==0.70.3 paver==1.2.4'
 PYTHON_CONFIGURATION='default@2.7.15.db9bad48:solaris10@2.7.8.db9bad48'
 BINARY_DIST_URI='http://binary.chevah.com/production'
 PIP_INDEX='http://pypi.chevah.com'

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,12 @@ Release notes for chevah.compat
 ===============================
 
 
+0.51.1 - 20/09/2018
+-------------------
+
+* Add path to more OSError raised on Windows.
+
+
 0.51.0 - 19/09/2018
 -------------------
 

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,20 +2,27 @@ Release notes for chevah.compat
 ===============================
 
 
-0.51.6 - 26/06/2018
+0.51.0 - 19/09/2018
+-------------------
+
+* When opening a file, if the OS error has no associated path, add the path
+  the the exception.
+
+
+0.50.6 - 26/06/2018
 -------------------
 
 * Use start of current year for date of virtual folders.
 
 
-0.51.5 - 22/06/2018
+0.50.5 - 22/06/2018
 -------------------
 
 * Fix detection of virtual path for nested virtual paths.
 * Add macOS on the list of case-insensitive path handling.
 
 
-0.51.4 - 21/06/2018
+0.50.4 - 21/06/2018
 -------------------
 
 * Disable the filesystem overlay functionality. You can no longer mix virtual
@@ -27,13 +34,13 @@ Release notes for chevah.compat
 * Add case insensitive behaviour for Windows.
 
 
-0.51.3 - 17/06/2018
+0.50.3 - 17/06/2018
 -------------------
 
 * Fix getAttributes and getStatus operations for root segments.
 
 
-0.51.2 - 16/06/2018
+0.50.2 - 16/06/2018
 -------------------
 
 * Restrict any mutating operation on the virtual path itself or for parts
@@ -41,7 +48,7 @@ Release notes for chevah.compat
 * Fix listing of deep virtual path which are not overlaid.
 
 
-0.51.1 - 15/06/2018
+0.50.1 - 15/06/2018
 -------------------
 
 * Fix listing of virtual path which are overlaid

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.51.0'
+VERSION = '0.51.1'
 
 
 class PublishCommand(Command):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.50.6'
+VERSION = '0.52.0'
 
 
 class PublishCommand(Command):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.52.0'
+VERSION = '0.51.0'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
Scope
=====

This updates the compat code to add filename when OSError has no filename.
For example on Windows.

Changes
=======

Refactor the code to add filename.

As a drive by, update the dev env for latest buildbot with local passwords.


How to try and test the changes
===============================

reviewers: @dumol 

We can use this PR to update the python package.

Please check what Python-package should I use.
