### PR TITLE
[#5082] Return attributes from folder iterations.

### DIFF
--- a/chevah/compat/posix_filesystem.py
+++ b/chevah/compat/posix_filesystem.py
@@ -749,7 +749,11 @@ class PosixFilesystemBase(object):
         """
         name = self._decodeFilename(entry.name)
         path = self._decodeFilename(entry.path)
-        stats = entry.stat()
+
+        with self._impersonateUser():
+            stats = entry.stat(follow_symlinks=False)
+            is_link = entry.is_symlink()
+
         mode = stats.st_mode
         is_directory = bool(stat.S_ISDIR(mode))
         if is_directory and sys.platform.startswith('aix'):
@@ -767,7 +771,7 @@ class PosixFilesystemBase(object):
             size=stats.st_size,
             is_file=bool(stat.S_ISREG(mode)),
             is_folder=is_directory,
-            is_link=entry.is_symlink(),
+            is_link=is_link,
             modified=stats.st_mtime,
             mode=mode,
             hardlinks=stats.st_nlink,

--- a/chevah/compat/posix_filesystem.py
+++ b/chevah/compat/posix_filesystem.py
@@ -763,6 +763,12 @@ class PosixFilesystemBase(object):
         # scandir result is slow.
         inode = stats.st_ino
 
+        modified = stats.st_mtime
+        if os.name == 'nt':
+            # On Windows, scandir gets float precision while
+            # getAttributes only integer.
+            modified = long(modified)
+
         return FileAttributes(
             name=name,
             path=path,
@@ -770,7 +776,7 @@ class PosixFilesystemBase(object):
             is_file=bool(stat.S_ISREG(mode)),
             is_folder=is_directory,
             is_link=is_link,
-            modified=stats.st_mtime,
+            modified=modified,
             mode=mode,
             hardlinks=stats.st_nlink,
             uid=stats.st_uid,

--- a/chevah/compat/posix_filesystem.py
+++ b/chevah/compat/posix_filesystem.py
@@ -767,7 +767,7 @@ class PosixFilesystemBase(object):
         if os.name == 'nt':
             # On Windows, scandir gets float precision while
             # getAttributes only integer.
-            modified = long(modified)
+            modified = int(modified)
 
         return FileAttributes(
             name=name,

--- a/chevah/compat/testing/testcase.py
+++ b/chevah/compat/testing/testcase.py
@@ -1067,6 +1067,12 @@ class ChevahTestCase(TwistedTestCase, AssertionMixin):
         """
         return patch.object(*args, **kwargs)
 
+    def now(self):
+        """
+        Return current Unix timestamp.
+        """
+        return time.time()
+
     @classmethod
     def cleanTemporaryFolder(cls):
         """

--- a/chevah/compat/tests/normal/test_filesystem.py
+++ b/chevah/compat/tests/normal/test_filesystem.py
@@ -3772,6 +3772,12 @@ class TestLocalFilesystemVirtualFolder(CompatTestCase):
         self.assertItemsEqual(expected, result)
 
         result = sut.iterateFolderContent([])
+        expected = [
+            '\N{sun}base',
+            'non-virtual\N{sun}',
+            'other-real\N{sun}',
+            'more-virtual',
+            ]
         self.assertIteratorItemsEqual(expected, result)
 
         expected = [
@@ -3812,6 +3818,8 @@ class TestLocalFilesystemVirtualFolder(CompatTestCase):
         """
         It can list a virtual folder as member of a parent folder mixed
         with non-virtual members.
+
+        The real members are shadowed by the virtual members.
         """
 
         sut = self.getFilesystem(virtual_folders=[
@@ -3826,11 +3834,15 @@ class TestLocalFilesystemVirtualFolder(CompatTestCase):
         mk.fs.createFolder(segments + ['child-folder'])
         mk.fs.createFile(segments + ['child-file'])
 
-        expected = ['child-file', 'virtual\N{cloud}']
-
         result = sut.getFolderContent(['non-virtual\N{sun}'])
-        self.assertItemsEqual(expected, result)
+        self.assertItemsEqual(['child-file', 'virtual\N{cloud}'], result)
 
+        expected = [
+            sut._getPlaceholderAttributes([
+                'non-virtual\N{sun}', 'child-file']),
+            sut._getPlaceholderAttributes([
+                'non-virtual\N{sun}', 'virtual\N{cloud}']),
+            ]
         result = sut.iterateFolderContent(['non-virtual\N{sun}'])
         self.assertIteratorItemsEqual(expected, result)
 
@@ -3838,7 +3850,10 @@ class TestLocalFilesystemVirtualFolder(CompatTestCase):
         self.assertEqual(['non-virtual\N{sun}'], result)
 
         result = sut.iterateFolderContent([])
-        self.assertIteratorItemsEqual(['non-virtual\N{sun}'], result)
+        # Even if non-virtual is real, we get the attributes for the virtual
+        # path.
+        self.assertIteratorItemsEqual(
+            [sut._getPlaceholderAttributes(['non-virtual\N{sun}'])], result)
 
     @conditionals.skipOnPY3()
     def test_getFolderContent_virtual_deep_member(self):
@@ -3857,6 +3872,12 @@ class TestLocalFilesystemVirtualFolder(CompatTestCase):
         result = sut.getFolderContent(['\N{sun}base'])
         self.assertItemsEqual(expected, result)
 
+        expected = [
+            sut._getPlaceholderAttributes([
+                '\N{sun}base', 'deep\N{cloud}']),
+            sut._getPlaceholderAttributes([
+                '\N{sun}base', 'other\N{sun}']),
+            ]
         result = sut.iterateFolderContent(['\N{sun}base'])
         self.assertIteratorItemsEqual(expected, result)
 
@@ -3864,6 +3885,10 @@ class TestLocalFilesystemVirtualFolder(CompatTestCase):
         result = sut.getFolderContent(['\N{sun}base', 'deep\N{cloud}'])
         self.assertItemsEqual(expected, result)
 
+        expected = [
+            sut._getPlaceholderAttributes([
+                '\N{sun}base', 'deep\N{cloud}', 'virt\N{sun}']),
+            ]
         result = sut.iterateFolderContent(['\N{sun}base', 'deep\N{cloud}'])
         self.assertIteratorItemsEqual(expected, result)
 

--- a/chevah/compat/tests/normal/test_filesystem.py
+++ b/chevah/compat/tests/normal/test_filesystem.py
@@ -3888,7 +3888,7 @@ class TestLocalFilesystemVirtualFolder(CompatTestCase):
 
         The real members are shadowed by the virtual members.
         """
-
+        self.maxDiff = None
         sut = self.getFilesystem(virtual_folders=[
             (['non-virtual\N{sun}', 'virtual\N{cloud}'], mk.fs.temp_path),
             (['non-virtual\N{sun}', 'child-file', 'other'], mk.fs.temp_path),
@@ -3924,6 +3924,31 @@ class TestLocalFilesystemVirtualFolder(CompatTestCase):
         self.assertIteratorItemsEqual([
             mk.fs._getPlaceholderAttributes(segments),
             mk.fs.getAttributes(other_segments)
+            ],
+            result)
+
+    @conditionals.skipOnPY3()
+    def test_iterateFolderContent_virtual_overlap(self):
+        """
+        When iterating over a folder with virtual members,
+        the real members are shadowed by the virtual members.
+        """
+        self.maxDiff = None
+        sut = self.getFilesystem(virtual_folders=[
+            (['non-virtual\N{sun}', 'virtual\N{cloud}'], mk.fs.temp_path),
+            (['non-virtual\N{sun}', 'child-file', 'other'], mk.fs.temp_path),
+            ])
+
+        # We create the folders after the filesystem was initialized as
+        # otherwise it will fail to initialized as it makes checks at init
+        # time for overlapping.
+        _, segments = self.tempFolder('non-virtual\N{sun}')
+
+        result = sut.iterateFolderContent([])
+        # Even if non-virtual is real, we get the attributes for the virtual
+        # path.
+        self.assertIteratorItemsEqual([
+            mk.fs._getPlaceholderAttributes(segments),
             ],
             result)
 

--- a/chevah/compat/tests/normal/test_filesystem.py
+++ b/chevah/compat/tests/normal/test_filesystem.py
@@ -3837,6 +3837,10 @@ class TestLocalFilesystemVirtualFolder(CompatTestCase):
             sut.getAttributes(['other-real\N{sun}']),
             sut._getPlaceholderAttributes(['more-virtual']),
             ]
+        if self.os_name == 'windows':
+            # On Windows, we don't get inode when iterating over real members.
+            expected[1].node_id = 0
+            expected[2].node_id = 0
         self.assertIteratorItemsEqual(expected, result)
 
         expected = [
@@ -3851,6 +3855,10 @@ class TestLocalFilesystemVirtualFolder(CompatTestCase):
             sut.getAttributes(['non-virtual\N{sun}']),
             sut.getAttributes(['other-real\N{sun}']),
             ]
+        if self.os_name == 'windows':
+            # On Windows, we don't get inode when iterating.
+            expected[0].node_id = 0
+            expected[1].node_id = 0
         self.assertIteratorItemsEqual(expected, result)
 
     @conditionals.skipOnPY3()
@@ -3878,6 +3886,10 @@ class TestLocalFilesystemVirtualFolder(CompatTestCase):
             mk.fs.getAttributes(segments + ['child-folder']),
             mk.fs.getAttributes(segments + ['child-file\N{sun}']),
             ]
+        if self.os_name == 'windows':
+            # On Windows, we don't get inode when iterating over real members.
+            expected[0].node_id = 0
+            expected[1].node_id = 0
         self.assertIteratorItemsEqual(expected, result)
 
     @conditionals.skipOnPY3()
@@ -3888,7 +3900,6 @@ class TestLocalFilesystemVirtualFolder(CompatTestCase):
 
         The real members are shadowed by the virtual members.
         """
-        self.maxDiff = None
         sut = self.getFilesystem(virtual_folders=[
             (['non-virtual\N{sun}', 'virtual\N{cloud}'], mk.fs.temp_path),
             (['non-virtual\N{sun}', 'child-file', 'other'], mk.fs.temp_path),
@@ -3921,11 +3932,15 @@ class TestLocalFilesystemVirtualFolder(CompatTestCase):
         result = sut.iterateFolderContent([])
         # Even if non-virtual is real, we get the attributes for the virtual
         # path.
-        self.assertIteratorItemsEqual([
+
+        expected = [
             mk.fs._getPlaceholderAttributes(segments),
             mk.fs.getAttributes(other_segments)
-            ],
-            result)
+            ]
+        if self.os_name == 'windows':
+            # On Windows, we don't get inode when iterating over real members.
+            expected[1].node_id = 0
+        self.assertIteratorItemsEqual(expected, result)
 
     @conditionals.skipOnPY3()
     def test_iterateFolderContent_virtual_overlap(self):
@@ -3933,7 +3948,6 @@ class TestLocalFilesystemVirtualFolder(CompatTestCase):
         When iterating over a folder with virtual members,
         the real members are shadowed by the virtual members.
         """
-        self.maxDiff = None
         sut = self.getFilesystem(virtual_folders=[
             (['non-virtual\N{sun}', 'virtual\N{cloud}'], mk.fs.temp_path),
             (['non-virtual\N{sun}', 'child-file', 'other'], mk.fs.temp_path),

--- a/paver.conf
+++ b/paver.conf
@@ -1,4 +1,4 @@
 BASE_REQUIREMENTS='chevah-brink==0.70.3 paver==1.2.4'
-PYTHON_CONFIGURATION='default@2.7.15.1afde4e1:solaris10@2.7.8.1afde4e1'
+PYTHON_CONFIGURATION='default@2.7.15.1afde4e1:solaris10@2.7.8.1afde4e1:debian7@2.7.15.db42da13'
 BINARY_DIST_URI='http://binary.chevah.com/production'
 PIP_INDEX='http://pypi.chevah.com'

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,12 @@ Release notes for chevah.compat
 ===============================
 
 
+0.52.0 - 03/10/2018
+-------------------
+
+* Return attributes in folder iterator.
+
+
 0.51.1 - 20/09/2018
 -------------------
 

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,12 @@ Release notes for chevah.compat
 ===============================
 
 
+0.52.2 - 04/10/2018
+-------------------
+
+* Virtual folders always shadow the real folders.
+
+
 0.52.1 - 03/10/2018
 -------------------
 

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,12 @@ Release notes for chevah.compat
 ===============================
 
 
+0.52.3 - 04/10/2018
+-------------------
+
+* Use same modified date on Windows for folder iteration as with getAttributes.
+
+
 0.52.2 - 04/10/2018
 -------------------
 

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,13 @@ Release notes for chevah.compat
 ===============================
 
 
+0.52.1 - 03/10/2018
+-------------------
+
+* Don't follow links when getting the attributes for iterated folder.
+* Use impersonation when getting the attributes during the folder iteration.
+
+
 0.52.0 - 03/10/2018
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.51.1'
+VERSION = '0.52.0'
 
 
 class PublishCommand(Command):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.52.2'
+VERSION = '0.52.3'
 
 
 class PublishCommand(Command):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.52.0'
+VERSION = '0.52.1'
 
 
 class PublishCommand(Command):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.52.1'
+VERSION = '0.52.2'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
Scope
=====

This updates the folder iteraction fuction to return file attributes, instead of just names.
In this way, you don't need an extra call to get the attributes for each member.


Changes
=======

Convert scandir attributes to FileAttributes, update test.


How to try and test the changes
===============================

reviewers: @dumol 

Not much to review. Hope all slaves are ok and we can add arm64 works.