### PR TITLE
[#5200] Overwrite destination on rename in Windows

### DIFF
--- a/chevah/compat/testing/testcase.py
+++ b/chevah/compat/testing/testcase.py
@@ -1199,7 +1199,7 @@ class ChevahTestCase(TwistedTestCase, AssertionMixin):
         """
         return mk.fs.makePathInTemp(prefix=prefix, suffix=suffix)
 
-    def tempFile(self, content='', prefix='', suffix=''):
+    def tempFile(self, content='', prefix='', suffix='', cleanup=True):
         """
         Return (path, segments) for a new file created in temp which is
         auto cleaned.
@@ -1207,7 +1207,8 @@ class ChevahTestCase(TwistedTestCase, AssertionMixin):
         segments = mk.fs.createFileInTemp(prefix=prefix, suffix=suffix)
         path = mk.fs.getRealPathFromSegments(segments)
 
-        self.addCleanup(mk.fs.deleteFile, segments)
+        if cleanup:
+            self.addCleanup(mk.fs.deleteFile, segments)
 
         try:
             opened_file = mk.fs.openFileForWriting(segments, utf8=False)

--- a/chevah/compat/tests/normal/test_filesystem.py
+++ b/chevah/compat/tests/normal/test_filesystem.py
@@ -1460,6 +1460,20 @@ class TestLocalFilesystem(DefaultFilesystemTestCase):
         self.assertFalse(self.filesystem.exists(initial_segments))
         self.assertTrue(self.filesystem.exists(self.test_segments))
 
+    def test_rename_file_overwrite_destination(self):
+        """
+        It will overwrite existing file.
+        """
+        _, source_segments = self.tempFile(prefix='src-', cleanup=False)
+        _, destination_segments = self.tempFile(prefix='dst-')
+        self.assertTrue(self.filesystem.exists(source_segments))
+        self.assertTrue(self.filesystem.exists(destination_segments))
+
+        self.filesystem.rename(source_segments, destination_segments)
+
+        self.assertFalse(self.filesystem.exists(source_segments))
+        self.assertTrue(self.filesystem.exists(destination_segments))
+
     def test_rename_folder(self):
         """
         System test for folder renaming.

--- a/paver.conf
+++ b/paver.conf
@@ -1,4 +1,4 @@
 BASE_REQUIREMENTS='chevah-brink==0.70.3 paver==1.2.4'
-PYTHON_CONFIGURATION='default@2.7.15.1afde4e1:solaris10@2.7.8.1afde4e1:debian7@2.7.15.db42da13'
+PYTHON_CONFIGURATION='default@2.7.15.d0cd044f:solaris10@2.7.8.d0cd044f'
 BINARY_DIST_URI='http://binary.chevah.com/production'
 PIP_INDEX='http://pypi.chevah.com'

--- a/paver.sh
+++ b/paver.sh
@@ -544,6 +544,16 @@ detect_os() {
             if [ "$update" -lt 8 ]; then
                 OS="solaris10u3"
             fi
+        # Solaris 11 releases prior to 11.4 were bundled with OpenSSL libraries
+        # missing support for Elliptic-curve crypto. From here on:
+        #     * Solaris 11.4 (or newer) with OpenSSL 1.0.2 is "solaris11".
+        #     * Solaris 11.2/11.3 with OpenSSL 1.0.1 is "solaris112".
+        #     * Solaris 11.0/11.1 with OpenSSL 1.0.0 is not supported.
+        elif [ "${OS}" = "solaris11" ]; then
+            minor_version=$(uname -v | cut -d'.' -f2)
+            if [ "$minor_version" -lt 4 ]; then
+                OS="solaris112"
+            fi
         fi
 
     elif [ "${OS}" = "aix" ]; then
@@ -640,8 +650,14 @@ detect_os() {
                     # Arch Linux is a rolling distro, no version info available.
                     OS="archlinux"
                     ;;
+                "amzn")
+                    os_version_raw="$VERSION_ID"
+                    check_os_version "$distro_fancy_name" 2 \
+                        "$os_version_raw" os_version_chevah
+                    OS="amazon${os_version_chevah}"
+                    ;;
                 *)
-                    echo "Unsupported Linux distribution type: $linux_distro."
+                    echo "Unsupported Linux distribution: $distro_fancy_name."
                     exit 15
                     ;;
             esac


### PR DESCRIPTION
Scope
=====

On  Windows, default rename fails if destination exists.

But we don't want to fail so that we have the same behaviour on all OS.


Changes
=======

Handle error on rename on Windows and delete the destination

As a drive-by I have also updated the paver.sh and paver.conf

How to try and test the changes
===============================

reviewers: @dumol 

This is more FYI.