### PR TITLE
[#5311] Shorter OS names.

### DIFF
--- a/chevah/compat/testing/assertion.py
+++ b/chevah/compat/testing/assertion.py
@@ -30,14 +30,16 @@ class Contains(object):
     """
     Marker class used in tests when something needs to contain a value.
     """
-    def __init__(self, value):
-        self.value = value
+    def __init__(self, *value):
+        self._values = value
 
     def __eq__(self, other):
-        return self.value in other
+        for value in self._values:
+            if value not in other:
+                return False
 
     def __hash__(self):  # noqa:cover
-        return hash(self.value)
+        return hash(self._value[0])
 
 
 class AssertionMixin(object):
@@ -46,8 +48,6 @@ class AssertionMixin(object):
 
     The assertions from here should not overwrite anything.
     """
-
-    Contains = Contains
 
     @classmethod
     def assertTempIsClean(cls):
@@ -133,39 +133,6 @@ class AssertionMixin(object):
             message = u'Failure %s is not of type %s' % (
                 text_type(failure), failure_class)
             raise AssertionError(message.encode('utf-8'))
-
-    def _checkData(self, kind, kind_id, expected_data, current_data):
-        """
-        Helper for sharing same code between various data checkers.
-        """
-        for key, value in expected_data.items():
-            try:
-                current_value = current_data[key]
-
-                if isinstance(value, Contains):
-                    if value.value not in current_value:
-                        message = (
-                            u'%s %s, for data "%s" does not contains "%s", '
-                            u'but is "%s"') % (
-                            kind, text_type(kind_id), key, value.value,
-                            current_value)
-                        raise AssertionError(message.encode('utf-8'))
-                else:
-                    if value != current_value:
-                        message = (
-                            u'%s %s, for data "%s" is not "%s", but "%s"') % (
-                            kind,
-                            text_type(kind_id),
-                            key,
-                            repr(value),
-                            repr(current_value),
-                            )
-                        raise AssertionError(message.encode('utf-8'))
-            except KeyError:  # noqa:cover
-                values = (
-                    kind, text_type(kind_id), repr(key), repr(current_data))
-                message = u'%s %s, has no data "%s". Data is:\n%s' % values
-                raise AssertionError(message.encode('utf-8'))
 
     def assertIsEmpty(self, target):
         """

--- a/chevah/compat/tests/normal/test_testing.py
+++ b/chevah/compat/tests/normal/test_testing.py
@@ -10,7 +10,6 @@ from six import text_type
 from threading import Thread, Event
 
 from chevah.compat.testing import ChevahTestCase, mk
-from chevah.compat.testing.assertion import Contains
 
 
 class TestFactory(ChevahTestCase):
@@ -83,7 +82,7 @@ class TestFactory(ChevahTestCase):
             def run(self):
                 event.wait()
 
-        self.excepted_threads = self.excepted_threads + [Contains('TestTh')]
+        self.excepted_threads = self.excepted_threads + ['TestTh']
 
         thread = TestThread(name="TestThread")
         thread.start()

--- a/paver.conf
+++ b/paver.conf
@@ -1,4 +1,4 @@
-BASE_REQUIREMENTS='chevah-brink==0.70.3 paver==1.2.4'
-PYTHON_CONFIGURATION='default@2.7.16.9c55c222:solaris10@2.7.8.9c55c222:openbsd65@2.7.16.906c18e5'
+BASE_REQUIREMENTS='chevah-brink==0.71.0 paver==1.2.4'
+PYTHON_CONFIGURATION='default@2.7.16.6560b361:solaris10@2.7.8.6560b361'
 BINARY_DIST_URI='http://binary.chevah.com/production'
 PIP_INDEX='http://pypi.chevah.com'

--- a/paver.conf
+++ b/paver.conf
@@ -1,4 +1,4 @@
-BASE_REQUIREMENTS='chevah-brink==0.71.0 paver==1.2.4'
+BASE_REQUIREMENTS='chevah-brink==0.71.1 paver==1.2.4'
 PYTHON_CONFIGURATION='default@2.7.16.6560b361:solaris10@2.7.8.6560b361'
 BINARY_DIST_URI='http://binary.chevah.com/production'
 PIP_INDEX='http://pypi.chevah.com'

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -1,6 +1,26 @@
 Release notes for chevah.compat
 ===============================
 
+
+0.55.4 - 22/08/2019
+-------------------
+
+* Update for short os names in brink.
+
+
+0.55.3 - 21/08/2019
+-------------------
+
+* Fix py3 exception in nose_runner script.
+
+
+0.55.2 - 21/08/2019
+-------------------
+
+* Remove support for `Contains`.
+* Fix print function in nose_runner script.
+
+
 0.55.1 - 17/06/2019
 -------------------
 

--- a/scripts/nose_runner.py
+++ b/scripts/nose_runner.py
@@ -7,6 +7,7 @@ This is needed since on Unix the tests are executed using sudo.
 
 It is also used to trigger coverage reporting.
 """
+from __future__ import absolute_import, print_function
 import os
 import sys
 
@@ -15,7 +16,7 @@ if have_coverage:
     import coverage
     cov = coverage.Coverage(auto_data=True, config_file='.coveragerc')
     cov.start()
-    print 'Coverage reporting started.'
+    print('Coverage reporting started.')
 else:
     cov = None
 
@@ -57,18 +58,18 @@ def main():
         ]
     try:
         nose_main(addplugins=plugins)
-    except SystemExit, error:
+    except SystemExit as error:
         if cov:
             cov.stop()
             cov.save()
         import threading
-        print "Max RSS: %s" % ChevahTestCase.getPeakMemoryUsage()
+        print("Max RSS: %s" % ChevahTestCase.getPeakMemoryUsage())
         threads = threading.enumerate()
         if len(threads) < 2:
             # No running threads, other than main so we can exit as normal.
             sys.exit(error.code)
         else:
-            print "There are still active threads: %s" % threads
+            print("There are still active threads: %s" % threads)
 
             # We do a brute force exit here, since sys.exit will wait for
             # unjoined threads.

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.55.1'
+VERSION = '0.55.4'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
Scope
=====

`compat` tests do not pass with the shorter win OS name, which prevents testing new `python-package` builds successfully on Windows slaves.


Changes
=======

Updated paver stuff from `python-package`.


How to try and test the changes
===============================

reviewers: **WIP**