### PR TITLE
Assume /Users on macOS when not buildslave user.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+#
+# Experimental Travis-CI
+#
+# For now, the build matrix has a single member: linux-arm64
+# Pinned on the oldest available distribution, to get a generic Linux build.
+
+language: c
+
+jobs:
+  include:
+    - os: linux
+      dist: xenial
+      arch: arm64
+    - os: osx
+      osx_image: xcode10.1
+    - os: osx
+      osx_image: xcode11.3
+
+install: skip
+
+script:
+  - ./brink.sh detect_os
+  - ./brink.sh deps
+  - ./brink.sh test_ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 #
-# Experimental Travis-CI
+# Experimental Travis CI.
 #
-# For now, the build matrix has a single member: linux-arm64
-# Pinned on the oldest available distribution, to get a generic Linux build.
+# Linux ARM64 target is pinned on the oldest distribution available on Travis,
+# to get a generic ARM64 Linux build.
 
-language: c
+language: minimal
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 # Experimental Travis CI.
 #
 # Linux ARM64 target is pinned on the oldest distribution available on Travis,
-# to get a generic ARM64 Linux build.
+# thus matching a generic ARM64 Linux build.
 
 language: minimal
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -30,7 +30,7 @@ Remote test
 
 You should specify the builder name to run the tests::
 
-    $ ./brink.sh test_remote ubuntu-1204-32 --wait SOME_TEST
+    $ ./brink.sh test_remote ubuntu-2004 --wait SOME_TEST
 
 You can trigger a remote session by using this code instead of the regular
 `import pdb; pdb.set_trace`::
@@ -46,7 +46,7 @@ You will need access to the VPN as you will connect directly to the slave.
 PAM
 ---
 
-PAM test requires the chevah-pam-test PAM module to be enabled.
+PAM tests require the chevah-pam-test PAM module to be enabled.
 
 Create a file `/etc/pam.d/chevah-pam-test` with the following content::
 

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ chevah-compat
 .. image:: https://github.com/chevah/compat/workflows/GitHub-CI/badge.svg
   :target: https://github.com/chevah/compat/actions
 
-.. image:: https://api.travis-ci.com/chevah/compat.svg?branch=master
+.. image:: https://travis-ci.com/chevah/compat.svg?branch=master
   :target: https://travis-ci.com/github/chevah/compat
 
 

--- a/README.rst
+++ b/README.rst
@@ -22,18 +22,17 @@ Depends on:
 Unified interface for working with operating system accounts on Unix
 and Windows, see IOSUsers.
 
-Support for staring Unix daemon and installing and starting Windows services.
+Support for starting Unix daemons and installing/starting Windows services.
 
-Importing this module on Windows will populate the sys.argv with Unicode
-values.
+Importing this module on Windows populates sys.argv with Unicode values.
 
-Unified interface for working with operating system file systems provides:
+The unified interface for working with operating system file systems provides:
 
 * Unicode
-* allow impersonated filesystem access
-* allow chrooted filesystem access
+* allowing impersonated filesystem access
+* allowing chrooted filesystem access
 * single internal path separator: always '/'.
-* listing root folder. On Windows '/' will list all
-  available drives. '/c/' will list c:\\ content.
-* setting/getting filesystem node owner/groups.
-* open file in various modes: read-only, write-only, append,
+* listing root directory (on Windows, '/' lists all available drives,
+  while '/c/' lists drive c:)
+* setting/getting filesystem node owner/groups
+* open files in various modes: read-only, write-only, append.

--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,9 @@ chevah-compat
 .. image:: https://github.com/chevah/compat/workflows/GitHub-CI/badge.svg
   :target: https://github.com/chevah/compat/actions
 
+.. image:: https://api.travis-ci.com/chevah/compat.svg?branch=master
+  :target: https://travis-ci.com/github/chevah/compat
+
 
 Chevah OS Compatibility Layer.
 

--- a/brink.conf
+++ b/brink.conf
@@ -1,5 +1,5 @@
-BASE_REQUIREMENTS='pip==20.1.1 chevah-brink==0.74.2 paver==1.2.4'
-PYTHON_CONFIGURATION='default@2.7.18.4b61bd67:sol10@2.7.8.4b61bd67'
+BASE_REQUIREMENTS='pip==20.1.1 chevah-brink==0.75 paver==1.2.4'
+PYTHON_CONFIGURATION='default@2.7.18.4b61bd67:sol10@2.7.8.4b61bd67:lnx@2.7.18.99d5a68f'
 BINARY_DIST_URI='http://binary.chevah.com/production'
 PIP_INDEX='http://pypi.chevah.com/simple'
 CHEVAH_BUILD_DIR='build-compat'

--- a/brink.sh
+++ b/brink.sh
@@ -138,8 +138,6 @@ clean_build() {
     delete_folder 'publish'
     echo "Cleaning pyc files ..."
 
-    # AIX's find complains if there are no matching files when using +.
-    [ $(uname) == AIX ] && touch ./dummy_file_for_AIX.pyc
     # Faster than '-exec rm {} \;' and supported in most OS'es,
     # details at http://www.in-ulm.de/~mascheck/various/find/#xargs
     find ./ -name '*.pyc' -exec rm {} +
@@ -662,7 +660,7 @@ check_linux_glibc() {
     fi
 
     # We pass here because:
-    #   1. Building python-package should work with an older glibc version.
+    #   1. Building Python should work with an older glibc version.
     #   2. Our generic "lnx" runtime might work with a slightly older glibc 2.
     if [ ${glibc_version_array[1]} -lt ${supported_glibc2_version} ]; then
         (>&2 echo -n "Detected glibc version: ${glibc_version}. Versions older")
@@ -838,7 +836,7 @@ if [ "$COMMAND" = "purge" ] ; then
     exit 0
 fi
 
-# Initialize BUILD_ENV_VARS file when building python-package from scratch.
+# Initialize BUILD_ENV_VARS file when building Python from scratch.
 if [ "$COMMAND" == "detect_os" ]; then
     echo "PYTHON_VERSION=$PYTHON_NAME" > BUILD_ENV_VARS
     echo "OS=$OS" >> BUILD_ENV_VARS

--- a/brink.sh
+++ b/brink.sh
@@ -373,7 +373,7 @@ get_binary_dist() {
         rm -f $tar_gz_file
         rm -f $tar_file
         execute $DOWNLOAD_CMD $remote_base_url/${tar_gz_file}
-        execute gunzip $tar_gz_file
+        execute gunzip -f $tar_gz_file
         execute tar -xf $tar_file
         rm -f $tar_gz_file
         rm -f $tar_file

--- a/chevah/compat/tests/normal/test_system_users.py
+++ b/chevah/compat/tests/normal/test_system_users.py
@@ -46,8 +46,7 @@ class TestSystemUsers(CompatTestCase):
         # For buildslave, home folder is in srv.
         if mk.username == 'buildslave':
             self.assertEqual(u'/srv/' + mk.username, home_folder)
-        elif mk.username == 'runner' and self.os_name == 'osx':
-            # We are on macOS GitHub actions.
+        elif self.os_name == 'osx':
             self.assertEqual(u'/Users/' + mk.username, home_folder)
         else:
             self.assertEqual(u'/home/' + mk.username, home_folder)

--- a/pavement.py
+++ b/pavement.py
@@ -332,7 +332,7 @@ def build():
         pave.path.build, pave.getPythonLibPath(), 'chevah', 'compat',
         ])
 
-    # On AIX pip (setuptools) fails to re-install, so we do some custom
+    # On AIX, pip (setuptools) fails to re-install, so we do some custom
     # cleaning as a workaround.
     members = pave.fs.listFolder(pave.fs.join([
         pave.path.build, pave.getPythonLibPath()]))

--- a/pavement.py
+++ b/pavement.py
@@ -73,7 +73,7 @@ if os.name == 'posix':
         # This is required as any other version will try to also update pip.
         'lockfile==0.9.1',
         'pam==0.1.4.c3',
-        # Required for loading PAM lib on AIX.
+        # Required for loading PAM libs on AIX.
         'arpy==1.1.1.c2',
         ])
 

--- a/pavement.py
+++ b/pavement.py
@@ -81,6 +81,7 @@ if os.name == 'posix':
 BUILD_PACKAGES = [
     # Buildbot is used for try scheduler
     'buildbot==0.8.11.chevah11',
+    'SQLAlchemy>=1.3.18',
 
     # For PQM
     'chevah-github-hooks-server==0.1.6',
@@ -100,7 +101,7 @@ BUILD_PACKAGES = [
     'pylint==1.9.4',
     'astroid==1.6.6',
     # These are build packages, but are needed for testing the documentation.
-    'sphinx==1.2.2',
+    'sphinx==1.6.3',
     'repoze.sphinx.autointerface==0.7.1.c4',
     # Docutils is required for RST parsing and for Sphinx.
     'docutils==0.12.c1',
@@ -108,11 +109,11 @@ BUILD_PACKAGES = [
     # Packages required to run the test suite.
     # Never version of nose, hangs on closing some tests
     # due to some thread handling.
-    'nose==1.3.0.chevah10',
+    'nose==1.3.0.chevah11',
     'nose-randomly==1.2.5',
     'mock',
 
-    'coverage==4.4.1',
+    'coverage==4.5.4',
     'diff_cover==0.9.11',
     'codecov==2.1.7',
 


### PR DESCRIPTION
Scope
=====

`test_getHomeFolder_posix` fails for chevah/pythia on Travis' macOS.

More at https://travis-ci.com/github/chevah/pythia/jobs/398801185

Changes
=======

Always assume `/Users` on macOS when the user is not `buildslave`.

**Drive-by fixes**:
  * Overwrite existing file when unzipping the Python package tarball.
  * Added experimental Travis CI.
  * Updated brink/pavement stuff from server and pythia, without removing any supported OS.
  * Updated README accordingly.

How to try and test the changes
===============================

reviewers: @adiroiban 

Please review changes.