### PR TITLE
Fix path split for single quotes.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,12 +32,6 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
 
-    - name: Dump event data
-      run: |
-        cat  << EOF
-        ${{ toJSON(github.event) }}
-        EOF
-
     # Make sure we don't have multiple job
     - uses: chevah/auto-cancel-redundant-job@v1
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -58,6 +52,10 @@ jobs:
 
     - name: Deps
       run: ./brink.sh deps
+
+    - uses: twisted/python-info-action@v1.0.1
+      with:
+        python-path: build-compat/bin/python
 
     - name: Move build to Unicode path
       run: mv build-compat build-compat-ț

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Deps
       run: ./brink.sh deps
 
-    - uses: twisted/python-info-action@v1.0.1
+    - uses: twisted/python-info-action@v1
       with:
         python-path: build-compat/bin/python
 

--- a/chevah/compat/posix_filesystem.py
+++ b/chevah/compat/posix_filesystem.py
@@ -112,11 +112,17 @@ class PosixFilesystemBase(object):
                 )
 
     def _pathSplitRecursive(self, path):
-        '''Recursive split of a path.'''
-        separators = os.path.sep
-        if os.path.altsep:
-            separators += os.path.altsep
-        segments = re.split('[%r]' % separators, path)
+        """
+        Recursive split of a path.
+        """
+        if os.path.sep == '\\':
+            # We are on Windows.
+            # Also handle Unix separators and escape the regex.
+            separators = '[\\\\/]'
+        else:
+            separators = '[/]'
+
+        segments = re.split(separators, path)
 
         if len(segments) > 0:
             segments[0] = segments[0].strip(':')

--- a/chevah/compat/posix_filesystem.py
+++ b/chevah/compat/posix_filesystem.py
@@ -118,7 +118,7 @@ class PosixFilesystemBase(object):
         if os.path.sep == '\\':
             # We are on Windows.
             # Also handle Unix separators and escape the regex.
-            separators = '[\\\\/]'
+            separators = r'[\\/]'
         else:
             separators = '[/]'
 

--- a/chevah/compat/tests/elevated/test_system_users.py
+++ b/chevah/compat/tests/elevated/test_system_users.py
@@ -384,9 +384,11 @@ class TestSystemUsers(SystemUsersTestCase):
         initial_uid, initial_gid = os.geteuid(), os.getegid()
         initial_groups = os.getgroups()
         test_user = mk.getTestUser(u'normal')
+        # os.getgroups can return duplicate group IDs and out of order.
+        # This is why we compare based on sets.
         self.assertNotEqual(
-            sorted(self.getGroupsIDForTestAccount()),
-            sorted(os.getgroups()),
+            set(self.getGroupsIDForTestAccount()),
+            set(os.getgroups()),
             )
 
         with system_users.executeAsUser(username=test_user.name):
@@ -411,8 +413,8 @@ class TestSystemUsers(SystemUsersTestCase):
                     impersonated_groups = list(set(impersonated_groups))
 
                 self.assertEqual(
-                    sorted(self.getGroupsIDForTestAccount()),
-                    sorted(impersonated_groups),
+                    set(self.getGroupsIDForTestAccount()),
+                    set(impersonated_groups),
                     )
 
         self.assertEqual(initial_uid, os.geteuid())

--- a/chevah/compat/tests/normal/test_filesystem.py
+++ b/chevah/compat/tests/normal/test_filesystem.py
@@ -130,6 +130,9 @@ class FilesystemTestMixin(FilesystemTestingHelpers):
         segments = self.filesystem.getSegments("//./a/b'c/d")
         self.assertEqual(['a', "b'c", 'd'], segments)
 
+        segments = self.filesystem.getSegments("/a/b - c/d")
+        self.assertEqual(['a', "b - c", 'd'], segments)
+
     def test_getPath_empty(self):
         """
         It will return `/` when segments are empty.

--- a/chevah/compat/tests/normal/test_filesystem.py
+++ b/chevah/compat/tests/normal/test_filesystem.py
@@ -101,7 +101,7 @@ class FilesystemTestingHelpers(object):
 
 class FilesystemTestMixin(FilesystemTestingHelpers):
     """
-    Common tests for filesystem.
+    Common tests for filesystem for all OSes..
     """
 
     def test_getSegments_upper_paths(self):
@@ -127,6 +127,9 @@ class FilesystemTestMixin(FilesystemTestingHelpers):
         segments = self.filesystem.getSegments(u'//./a/b')
         self.assertEqual([u'a', u'b'], segments)
 
+        segments = self.filesystem.getSegments("//./a/b'c/d")
+        self.assertEqual(['a', "b'c", 'd'], segments)
+
     def test_getPath_empty(self):
         """
         It will return `/` when segments are empty.
@@ -143,6 +146,9 @@ class FilesystemTestMixin(FilesystemTestingHelpers):
 
         path = self.filesystem.getPath([u'.', 'a', u'b'])
         self.assertEqual(u'/a/b', path)
+
+        path = self.filesystem.getPath(['.', 'a', "B'Quote"])
+        self.assertEqual("/a/B'Quote", path)
 
     def test_getPath_upper_paths(self):
         """

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,8 +2,14 @@ Release notes for chevah.compat
 ===============================
 
 
+0.58.4 - 2021-03-17
+-------------------
+
+* Fix Unix and Windows path normalization to handle single quote characters.
+
+
 0.58.3 - 2020-11-09
---------------------------
+-------------------
 
 * Allow cryptography 3.2 with OpenSSL 1.0.2.
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.58.3'
+VERSION = '0.58.4'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
Scope
=====

This fix a critical bug in which path containing single quotes are not handled corretly.

The single quote is replaced for a path separator.

For example, with the old code a path line 
```
/some/O`Reilly/file

was converted in 

/some/O/Reilly/file
```


Changes
=======

Update the path split code and simplify it with explicit regrex escaping.

I have no idea why I have used `%r` there.


How to try and test the changes
===============================

reviewers: @danuker 

Check that changes make sense.

For now this is a quick fix as this is urgent

In the future we should start using https://hypothesis.readthedocs.io/en/latest/index.html for unit testing in this low level libraries so that we can generate all possible characters and make sure path splinting works for them.