### PR TITLE
Update for Twisted 20.3.0

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,8 +38,8 @@ jobs:
       matrix:
         container:
           - alpine:3.12
-          - amazon:2018.03
-          - amazon:2
+          - amazonlinux:2018.03
+          - amazonlinux:2
           - centos:7
           - centos:8.2.2004
           - centos:8
@@ -50,11 +50,25 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
 
-    - name: Alpine 3.12 setup
-      if: matrix.container == 'alpine:3.12'
+    - name: Alpine setup
+      if: startsWith(matrix.container, 'alpine')
       run: |
         apk update && apk upgrade
         apk add shadow sudo bash git libffi
+
+    # OpenSSL got updated in 8.3 from 1.1.1c to 1.1.1g.
+    - name: CentOS 8.2 setup
+      if: matrix.container == 'centos:8.2.2004'
+      run: |
+        sed -i s/^mirrorlist=/#mirrorlist=/ /etc/yum.repos.d/*.repo
+        sed -i s@^#baseurl=http://mirror.centos.org/\$contentdir/\$releasever/@baseurl=https://vault.centos.org/8.2.2004/@ /etc/yum.repos.d/*.repo
+
+    - name: Yum-based setup
+      if: startsWith(matrix.container, 'centos') || startsWith(matrix.container, 'amazon')
+      run: |
+        yum -y upgrade
+        yum -y install git
+
 
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,6 +50,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
 
+    # On Alpine, OpenSSL must be updated to latest version.
     - name: Alpine setup
       if: startsWith(matrix.container, 'alpine')
       run: |
@@ -65,10 +66,7 @@ jobs:
 
     - name: Yum-based setup
       if: startsWith(matrix.container, 'centos') || startsWith(matrix.container, 'amazon')
-      run: |
-        yum -y upgrade
-        yum -y install tar git
-
+      run: yum -y install tar git gjs
 
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,70 @@
+#
+# GitHub actions to test chevah-compat under Docker.
+#
+
+name: GitHub-CI-Docker
+
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+    - '**.py'
+  pull_request:
+    branches: [ master ]
+    paths:
+    - '**.py'
+
+
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: true
+
+
+jobs:
+
+
+  standard:
+
+    name: ${{ matrix.container }}
+    container: ${{ matrix.container }}
+    strategy:
+      fail-fast: false
+      matrix:
+        container:
+          - alpine:3.12
+
+    # ubuntu-latest is GitHub's newest well-suported Linux distro.
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+
+    - name: Alpine 3.12 setup
+      if: matrix.container == 'alpine:3.12'
+      run: |
+        apk update && apk upgrade
+        apk add bash git libffi
+
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+    - name: Cache build
+      uses: actions/cache@v2
+      with:
+        path: |
+          build-compat
+        key: ${{ runner.os }}-${{ hashFiles('pavement.py') }}-${{ hashFiles('brink.conf') }}-${{ matrix.container }}
+
+    - name: Deps
+      run: ./brink.sh deps
+
+    - uses: twisted/python-info-action@v1
+      with:
+        python-path: build-compat/bin/python
+
+    - name: Deps
+      run: ./brink.sh deps
+
+    - name: Test
+      run: ./brink.sh test_ci2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,6 +38,11 @@ jobs:
       matrix:
         container:
           - alpine:3.12
+          - amazon:2018.03
+          - amazon:2
+          - centos:7
+          - centos:8.2.2004
+          - centos:8
 
     # ubuntu-latest is GitHub's newest well-suported Linux distro.
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,6 +40,8 @@ jobs:
           - alpine:3.12
           - amazonlinux:2018.03
           - amazonlinux:2
+          - centos:5
+          - centos:6
           - centos:7
           - centos:8.2.2004
           - centos:8
@@ -67,7 +69,7 @@ jobs:
       if: startsWith(matrix.container, 'centos') || startsWith(matrix.container, 'amazon')
       run: |
         yum -y upgrade
-        yum -y install git
+        yum -y install tar git
 
 
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,12 +50,12 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
 
-    # On Alpine, OpenSSL must be updated to latest version.
+    # On Alpine, OpenSSL must be updated to latest version for python-package.
     - name: Alpine setup
       if: startsWith(matrix.container, 'alpine')
       run: |
         apk update && apk upgrade
-        apk add shadow sudo bash git libffi
+        apk add git bash libffi shadow sudo
 
     # OpenSSL got updated in 8.3 from 1.1.1c to 1.1.1g.
     - name: CentOS 8.2 setup
@@ -66,7 +66,7 @@ jobs:
 
     - name: Yum-based setup
       if: startsWith(matrix.container, 'centos') || startsWith(matrix.container, 'amazon')
-      run: yum -y install which tar git
+      run: yum -y install git tar which sudo
 
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -86,7 +86,7 @@ jobs:
         python-path: build-compat/bin/python
 
     # On a Docker container, everything runs as root by default.
-    - name: chevah user setup
+    - name: Chevah user setup
       run: |
         useradd -g adm -s /bin/bash -m chevah
         echo '%adm    ALL=NOPASSWD: ALL' >> /etc/sudoers

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,6 +21,11 @@ concurrency:
   cancel-in-progress: true
 
 
+env:
+  USER: chevah
+  CHEVAH_CONTAINER: yes
+
+
 jobs:
 
 
@@ -44,7 +49,7 @@ jobs:
       if: matrix.container == 'alpine:3.12'
       run: |
         apk update && apk upgrade
-        apk add bash git libffi
+        apk add shadow sudo bash git libffi
 
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
@@ -63,8 +68,12 @@ jobs:
       with:
         python-path: build-compat/bin/python
 
-    - name: Deps
-      run: ./brink.sh deps
+    # On a Docker container, everything runs as root by default.
+    - name: chevah user setup
+      run: |
+        useradd -g adm -s /bin/bash -m chevah
+        echo '%adm    ALL=NOPASSWD: ALL' >> /etc/sudoers
+        chown -R chevah .
 
     - name: Test
-      run: ./brink.sh test_ci2
+      run: su chevah -c "./brink.sh test_ci2"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -66,7 +66,7 @@ jobs:
 
     - name: Yum-based setup
       if: startsWith(matrix.container, 'centos') || startsWith(matrix.container, 'amazon')
-      run: yum -y install tar git gjs
+      run: yum -y install which tar git
 
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,8 +40,6 @@ jobs:
           - alpine:3.12
           - amazonlinux:2018.03
           - amazonlinux:2
-          - centos:5
-          - centos:6
           - centos:7
           - centos:8.2.2004
           - centos:8

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,20 @@ env:
 
 jobs:
 
+  static-checks:
+    runs-on: ubuntu-20.04
+
+    steps:
+
+    - uses: chevah/auto-cancel-redundant-job@v1
+    - uses: actions/checkout@v2
+    - name: Deps
+      run: ./brink.sh deps
+
+    - name: Lint
+      run: ./brink.sh lint --all
+
+
   ubuntu-2004-unicode-path:
     # The type of runner that the job will run on
     runs-on: ubuntu-20.04
@@ -32,16 +46,8 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
 
-    # Make sure we don't have multiple job
-    - uses: chevah/auto-cancel-redundant-job@v1
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
-      with:
-        fetch-depth: 2
-
-    - name: Fail on skip-ci
-      if: ${{ github.event.after }}
-      run: git log -1 --pretty=format:"%s" ${{ toJSON(github.event.after) }} | grep -v 'skip-ci'
 
     - name: Cache build
       uses: actions/cache@v2
@@ -78,8 +84,6 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    # Make sure we don't have multiple job
-    - uses: chevah/auto-cancel-redundant-job@v1
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
       with:
@@ -117,14 +121,7 @@ jobs:
   macos-unicode-path:
     runs-on: macos-latest
     steps:
-    - uses: chevah/auto-cancel-redundant-job@v1
     - uses: actions/checkout@v2
-      with:
-        fetch-depth: 2
-
-    - name: Fail on skip-ci
-      if: ${{ github.event.after }}
-      run: git log -1 --pretty=format:"%s" ${{ toJSON(github.event.after) }} | grep -v 'skip-ci'
 
     - name: Cache build
       uses: actions/cache@v2
@@ -161,14 +158,7 @@ jobs:
   windows:
     runs-on: windows-latest
     steps:
-    - uses: chevah/auto-cancel-redundant-job@v1
     - uses: actions/checkout@v2
-      with:
-        fetch-depth: 2
-
-    - name: Fail on skip-ci
-      if: ${{ github.event.after }}
-      run: git log -1 --pretty=format:"%s" ${{ toJSON(github.event.after) }} | grep -v 'skip-ci'
 
     - name: Cache build
       uses: actions/cache@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,6 +74,8 @@ jobs:
     - name: Tmate debug on failure
       if: failure() && env.TMATE_DEBUG == 'yes'
       uses: mxschmitt/action-tmate@v3
+      with:
+        limit-access-to-actor: true
 
     - name: Move build back to to ascii
       run: mv build-compat-ț build-compat
@@ -111,6 +113,8 @@ jobs:
     - name: Tmate debug on failure
       if: failure() && env.TMATE_DEBUG == 'yes'
       uses: mxschmitt/action-tmate@v3
+      with:
+        limit-access-to-actor: true
 
     - name: Publish cov
       run: ./brink.sh codecov_publish
@@ -145,6 +149,8 @@ jobs:
     - name: Tmate debug on failure
       if: failure() && env.TMATE_DEBUG == 'yes'
       uses: mxschmitt/action-tmate@v3
+      with:
+        limit-access-to-actor: true
 
     - name: Move build back to to ascii
       run: mv build-compat-ț build-compat

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,7 +162,12 @@ jobs:
 
 
   windows:
-    runs-on: windows-latest
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [ windows-2019, windows-2016 ]
+
     steps:
     - uses: actions/checkout@v2
 

--- a/brink.conf
+++ b/brink.conf
@@ -1,4 +1,4 @@
-BASE_REQUIREMENTS='pip==20.2.4 chevah-brink==0.78.1 paver==1.2.4'
+BASE_REQUIREMENTS='pip==20.2.4 chevah-brink==0.79.0 paver==1.2.4'
 PYTHON_CONFIGURATION='default@2.7.18.e26e753c'
 BINARY_DIST_URI='http://binary.chevah.com/production'
 PIP_INDEX='http://pypi.chevah.com/simple'

--- a/brink.sh
+++ b/brink.sh
@@ -643,6 +643,9 @@ check_linux_glibc() {
             ;;
     esac
 
+    echo "No specific runtime for the current version of this distribution..."
+    echo "Glibc version should be at least: 2.${supported_glibc2_version}."
+
     set +o errexit
 
     command -v ldd > /dev/null
@@ -687,6 +690,7 @@ check_linux_glibc() {
     set -o errexit
 
     # glibc 2 detected, we set $OS for a generic Linux build.
+    echo "Glibc version currently detected: ${glibc_version}."
     OS="lnx"
 }
 

--- a/brink.sh
+++ b/brink.sh
@@ -625,7 +625,7 @@ check_linux_glibc() {
     local glibc_version_array
     local supported_glibc2_version
     # Output to a file to avoid "write error: Broken pipe" with grep/head.
-    local ldd_output_file="/tmp/.chevah_glibc_version"
+    local ldd_output_file=".chevah_glibc_version"
 
     # Supported minimum minor glibc 2.X versions for various arches.
     # For x64, we build on CentOS 5.11 (Final) with glibc 2.5.

--- a/brink.sh
+++ b/brink.sh
@@ -600,12 +600,15 @@ check_os_version() {
     done
 
     if [ "$flag_supported" = 'false' ]; then
-        (>&2 echo "Current version of ${name_fancy} is too old: ${version_raw}")
-        (>&2 echo "Oldest supported ${name_fancy} version is: ${version_good}")
         if [ "$OS" = "Linux" ]; then
             # For old and/or unsupported Linux distros there's a second chance!
+            echo "Current major version of ${name_fancy} is ${version_raw}."
+            echo "For versions older than ${name_fancy} ${version_good},"
+            echo "the generic Linux runtime is used, if possible."
             check_linux_glibc
         else
+            (>&2 echo "Current version of ${name_fancy} is: ${version_raw}")
+            (>&2 echo "Oldest supported ${name_fancy} version: ${version_good}")
             exit 13
         fi
     fi
@@ -640,9 +643,6 @@ check_linux_glibc() {
             ;;
     esac
 
-    (>&2 echo -n "Couldn't detect a supported distribution. ")
-    (>&2 echo "Trying to treat it as generic Linux...")
-
     set +o errexit
 
     command -v ldd > /dev/null
@@ -660,6 +660,7 @@ check_linux_glibc() {
 
     # Tested with glibc 2.5/2.11.3/2.12/2.23/2.28-31 and eglibc 2.13/2.19.
     glibc_version=$(head -n 1 $ldd_output_file | rev | cut -d\  -f1 | rev)
+    rm $ldd_output_file
 
     if [[ $glibc_version =~ [^[:digit:]\.] ]]; then
         (>&2 echo "Glibc version should only have numbers and periods, but:")

--- a/chevah/compat/testing/testcase.py
+++ b/chevah/compat/testing/testcase.py
@@ -1016,7 +1016,7 @@ class ChevahTestCase(TwistedTestCase, AssertionMixin):
         for function, args, kwargs in reversed(self.__cleanup__):
             try:
                 function(*args, **kwargs)
-            except Exception as error:
+            except Exception as error:  # noqa:cover
                 self._teardown_errors.append(error)
 
         self.__cleanup__ = []
@@ -1046,7 +1046,7 @@ class ChevahTestCase(TwistedTestCase, AssertionMixin):
             except AssertionError as error:
                 errors.append(error.message)
 
-        if errors:
+        if errors:  # noqa:cover
             self._teardown_errors.append(AssertionError(
                 'There are temporary files or folders left over.\n %s' % (
                     '\n'.join(errors))))

--- a/chevah/compat/testing/testcase.py
+++ b/chevah/compat/testing/testcase.py
@@ -141,13 +141,12 @@ class TwistedTestCase(TestCase):
         Return current tasks of thread Pool, or [] when threadpool does not
         exists.
 
-        This should only be called at cleanup as it removed elements from
+        This should only be called at cleanup as it removes elements from
         the Twisted thread queue, which will never be called.
         """
         if not reactor.threadpool:
             return []
 
-        # Consume all the
         result = []
         while len(reactor.threadpool._team._pending):
             result.append(reactor.threadpool._team._pending.pop())

--- a/chevah/compat/tests/normal/testing/test_testcase.py
+++ b/chevah/compat/tests/normal/testing/test_testcase.py
@@ -365,8 +365,9 @@ class TestTwistedTestCase(ChevahTestCase):
         """
         It will cancel any pending jobs for the threads.
         """
-        def last_call():
-            # We don't wait for this.
+        def last_call():  # noqa:cover
+            # This is added to the thread queue, but does not has the time
+            # to be executed as our assertion will remove it from the queue.
             time.sleep(1)
 
         threads.deferToThread(last_call)

--- a/pavement.py
+++ b/pavement.py
@@ -78,15 +78,6 @@ BUILD_PACKAGES = [
     'buildbot==0.8.11.chevah11',
     'SQLAlchemy>=1.3.18',
 
-    # For PQM
-    'chevah-github-hooks-server==0.1.6',
-    'smmap==0.9.0',
-    'async==0.6.1',
-    'gitdb==0.6.4',
-    'gitpython==1.0.1',
-    'pygithub==1.34.0',
-    'pyjwt==1.6.4',  # Used by pygithub.
-
     # For Lint and static checkers.
     'scame==0.5.1',
     'pyflakes>=1.5.0',

--- a/pavement.py
+++ b/pavement.py
@@ -22,8 +22,6 @@ from brink.pavement_commons import (
     coverage_prepare,
     codecov_publish,
     default,
-    github,
-    harness,
     help,
     lint,
     merge_init,
@@ -33,11 +31,8 @@ from brink.pavement_commons import (
     SETUP,
     test_coverage,
     test_diff,
-    test_os_dependent,
-    test_os_independent,
     test_python,
     test_remote,
-    test_review,
     test_normal,
     test_super,
     )
@@ -63,7 +58,7 @@ if os.name == 'nt':
 # Keep run_packages in sync with setup.py.
 # These are the hard dependencies needed by the library itself.
 RUN_PACKAGES = [
-    'zope.interface==3.8.0',
+    'zope.interface==5.4.0.chevah1',
     'six==1.15.0',
     ]
 
@@ -120,8 +115,9 @@ BUILD_PACKAGES = [
     # used for remote debugging.
     'remote_pdb==1.2.0',
 
-    # Twisted is optionl, but we have it here for complete tests.
-    'twisted==15.5.0.chevah7',
+    # Twisted is optional, but we have it here for complete tests.
+    'Twisted==20.3.0.chevah1',
+    'service_identity==18.1.0',
 
     # We install wmi everywhere even though it is only used on Windows.
     'wmi==1.4.9',
@@ -141,8 +137,6 @@ buildbot_try
 coverage_prepare
 codecov_publish
 default
-github
-harness
 help
 lint
 merge_init
@@ -150,11 +144,8 @@ merge_commit
 pqm
 test_coverage
 test_diff
-test_os_dependent
-test_os_independent
 test_python
 test_remote
-test_review
 test_normal
 test_super
 
@@ -355,7 +346,7 @@ def build():
 
 
 @task
-@needs('test_python')
+@needs('build', 'test_python')
 @consume_args
 def test(args):
     """
@@ -493,15 +484,11 @@ def test_ci2(args):
         args = [args]
     test_type = env.get('TEST_TYPE', 'normal')
 
-    if test_type == 'os-independent':
-        os.environ[b'CODECOV_TOKEN'] = ''
-        return call_task('test_os_independent')
-
     if test_type == 'py3':
         os.environ[b'CODECOV_TOKEN'] = ''
         return call_task('test_py3', args=args)
 
-    exit_code = call_task('test_os_dependent', args=args)
+    exit_code = call_task('test_python', args=args)
 
     return exit_code
 

--- a/pavement.py
+++ b/pavement.py
@@ -83,7 +83,6 @@ BUILD_PACKAGES = [
     'pyflakes>=1.5.0',
     'chevah-js-linter==2.4.0',
     'pycodestyle==2.3.1',
-    'bandit==1.4.0',
     'pylint==1.9.4',
     'astroid==1.6.6',
     # These are build packages, but are needed for testing the documentation.
@@ -191,19 +190,12 @@ try:
     options.pycodestyle['enabled'] = True
     options.pycodestyle['hang_closing'] = True
 
-    options.bandit['enabled'] = True
-    options.bandit['exclude'] = [
-        'B104',  # Bind to 0.0.0.0
-        'B108',  # Hardcoded /tmp usage.
-        ]
+    options.bandit['enabled'] = False
 
     # For now pylint is disabled, as there are to many errors.
     options.pylint['enabled'] = False
     options.pylint['disable'] = ['C0103', 'C0330', 'R0902', 'W0212']
 
-    # For the testing and dev code we disable bandit.
-    options.test_options['bandit'] = options.bandit.copy()
-    options.test_options['bandit']['enabled'] = False
 
 except ImportError:
     # This will fail before we run `./brink.sh deps`

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -1,6 +1,12 @@
 Release notes for chevah.compat
 ===============================
 
+0.60.0 - 2121-04-28
+-------------------
+
+* Update for Twisted 20.3.0
+* Continue cleanup on error.
+
 
 0.59.3 - 2021-04-01
 -------------------

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.59.3'
+VERSION = '0.60.0'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
Scope
=====

This updates the compat testing helpers to work with latest Twisted that support Python 2.7.

We were using a very old Twisted version which was a mix of 12.1 and 15.1

With this change,  any future upgrade to Twisted should not require and update to compat.


Changes
=======


Update the test case.

Move `callCleanup` code fix from chevah/server 


As a drive by, move the static checks to GitHub Actions.
I have also removed the custom skip-ci code as GHA has native support now.
I have also update the brink deps... just in case.


How to try and test the changes
===============================

reviewers: @danuker 

FYI.

This will be used in a PR in chevah/server where  will implement Twisted update.