### PR TITLE
Add support for stacked cleanups.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,7 +28,6 @@ env:
 
 jobs:
 
-
   standard:
 
     name: ${{ matrix.container }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,10 @@ on:
     paths:
     - '**.py'
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 
 env:
   TMATE_DEBUG: 'no'
@@ -30,7 +34,6 @@ jobs:
 
     steps:
 
-    - uses: chevah/auto-cancel-redundant-job@v1
     - uses: actions/checkout@v2
     - name: Deps
       run: ./brink.sh deps

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,19 +29,6 @@ env:
 
 jobs:
 
-  static-checks:
-    runs-on: ubuntu-20.04
-
-    steps:
-
-    - uses: actions/checkout@v2
-    - name: Deps
-      run: ./brink.sh deps
-
-    - name: Lint
-      run: ./brink.sh lint --all
-
-
   ubuntu-2004-unicode-path:
     # The type of runner that the job will run on
     runs-on: ubuntu-20.04

--- a/.github/workflows/static_checks.yaml
+++ b/.github/workflows/static_checks.yaml
@@ -1,0 +1,29 @@
+#
+# GitHub actions to chevah-compat linters.
+#
+# Available VMs. Don't use `-latest` as we want to pin an OS version.
+# https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners
+#
+name: GitHub-Lint
+
+on: [push]
+
+
+concurrency:
+  group: static-checks-${{ github.ref }}
+  cancel-in-progress: true
+
+
+jobs:
+
+  static-checks:
+    runs-on: ubuntu-20.04
+
+    steps:
+
+    - uses: actions/checkout@v2
+    - name: Deps
+      run: ./brink.sh deps
+
+    - name: Lint
+      run: ./brink.sh lint --all

--- a/chevah/compat/testing/mockup.py
+++ b/chevah/compat/testing/mockup.py
@@ -331,7 +331,7 @@ class ChevahCommonsFactory(object):
         name = str(self.number()) + TEST_NAME_MARKER
         return prefix + name + ('a' * (length - len(name))) + suffix
 
-    def makeIPv4Address(self, host='localhost', port=None, protocol='TCP'):
+    def makeIPv4Address(self, host='127.0.0.1', port=None, protocol='TCP'):
         """
         Creates an IPv4 address.
         """
@@ -341,7 +341,8 @@ class ChevahCommonsFactory(object):
         ipv4 = address.IPv4Address(protocol, host, port)
         return ipv4
 
-    def makeIPv6Address(self, host='localhost', port=None, protocol='TCP'):
+    def makeIPv6Address(
+            self, host='0:0:0:0:0:0:0:1', port=None, protocol='TCP'):
         """
         Creates an IPv6 address.
         """

--- a/chevah/compat/testing/testcase.py
+++ b/chevah/compat/testing/testcase.py
@@ -963,6 +963,7 @@ class ChevahTestCase(TwistedTestCase, AssertionMixin):
     def setUp(self):
         super(ChevahTestCase, self).setUp()
         self.__cleanup__ = []
+        self._cleanup_stack = []
         self._teardown_errors = []
         self.test_segments = None
 
@@ -1019,6 +1020,20 @@ class ChevahTestCase(TwistedTestCase, AssertionMixin):
                 self._teardown_errors.append(error)
 
         self.__cleanup__ = []
+
+    def enterCleanup(self):
+        """
+        Called when start using stacked cleanups.
+        """
+        self._cleanup_stack.append(self.__cleanup__)
+        self.__cleanup__ = []
+
+    def exitCleanup(self):
+        """
+        To be called at the end of a stacked cleanup.
+        """
+        self.callCleanup()
+        self.__cleanup__ = self._cleanup_stack.pop()
 
     def _checkTemporaryFiles(self):
         """

--- a/chevah/compat/testing/testcase.py
+++ b/chevah/compat/testing/testcase.py
@@ -9,6 +9,7 @@ from __future__ import division
 from __future__ import absolute_import
 from six import text_type
 from six.moves import range
+import contextlib
 import inspect
 import threading
 import os
@@ -1034,6 +1035,17 @@ class ChevahTestCase(TwistedTestCase, AssertionMixin):
         """
         self.callCleanup()
         self.__cleanup__ = self._cleanup_stack.pop()
+
+    @contextlib.contextmanager
+    def stackedCleanup(self):
+        """
+        Context manager for stacked cleanups.
+        """
+        try:
+            self.enterCleanup()
+            yield
+        finally:
+            self.exitCleanup()
 
     def _checkTemporaryFiles(self):
         """

--- a/chevah/compat/tests/normal/testing/test_mockup.py
+++ b/chevah/compat/tests/normal/testing/test_mockup.py
@@ -184,12 +184,12 @@ class TestFactory(ChevahTestCase):
 
     def test_makeIPv4Address_default(self):
         """
-        Will return an TCP localhost address with a random port.
+        Will return an TCP IPv4 localhost address with a random port.
         """
         result = mk.makeIPv4Address()
 
         self.assertEqual('TCP', result.type)
-        self.assertEqual('localhost', result.host)
+        self.assertEqual('127.0.0.1', result.host)
         self.assertGreater(result.port, 20000)
         self.assertLess(result.port, 30000)
 
@@ -200,5 +200,16 @@ class TestFactory(ChevahTestCase):
         result = mk.makeIPv4Address(port=1234)
 
         self.assertEqual('TCP', result.type)
-        self.assertEqual('localhost', result.host)
+        self.assertEqual('127.0.0.1', result.host)
         self.assertEqual(result.port, 1234)
+
+    def test_makeIPv6Address_default(self):
+        """
+        Will return an TCP IPV6 localhost address with a random port.
+        """
+        result = mk.makeIPv6Address()
+
+        self.assertEqual('TCP', result.type)
+        self.assertEqual('0:0:0:0:0:0:0:1', result.host)
+        self.assertGreater(result.port, 20000)
+        self.assertLess(result.port, 30000)

--- a/chevah/compat/tests/normal/testing/test_testcase.py
+++ b/chevah/compat/tests/normal/testing/test_testcase.py
@@ -830,16 +830,16 @@ class TestChevahTestCase(ChevahTestCase):
         self.enterCleanup()
         self.addCleanup(medium_cleanup)
 
-        self.enterCleanup()
-        self.addCleanup(top_cleanup)
+        # Can also be used as context manager.
+        with self.stackedCleanup():
+            self.addCleanup(top_cleanup)
 
-        # Nothing called so far.
-        self.assertEqual([], self.base_stack_called)
-        self.assertEqual([], self.medium_stack_called)
-        self.assertEqual([], self.top_stack_called)
+            # Nothing called so far.
+            self.assertEqual([], self.base_stack_called)
+            self.assertEqual([], self.medium_stack_called)
+            self.assertEqual([], self.top_stack_called)
 
-        # Exit top cleanup stack.
-        self.exitCleanup()
+        # Exit top cleanup stack is implicit as part of the context manager.
         self.assertEqual([], self.base_stack_called)
         self.assertEqual([], self.medium_stack_called)
         self.assertEqual([True], self.top_stack_called)

--- a/chevah/compat/unix_filesystem.py
+++ b/chevah/compat/unix_filesystem.py
@@ -68,7 +68,7 @@ class UnixFilesystem(PosixFilesystemBase):
         See `ILocalFilesystem`.
         """
         segments = []
-        if path is None or path is u'':
+        if path is None or path == u'':
             return segments
 
         head = True

--- a/pavement.py
+++ b/pavement.py
@@ -87,8 +87,8 @@ BUILD_PACKAGES = [
     'astroid==1.6.6',
     # These are build packages, but are needed for testing the documentation.
     'sphinx==1.6.3',
-    'repoze.sphinx.autointerface==0.7.1.c4',
     # Docutils is required for RST parsing and for Sphinx.
+    'markupsafe==1.0',
     'docutils==0.12.c1',
 
     # Packages required to run the test suite.

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -1,7 +1,14 @@
 Release notes for chevah.compat
 ===============================
 
-0.60.0 - 2121-04-28
+
+0.61.0 - 2021-06-28
+-------------------
+
+* Add support for stacked test cleanups.
+
+
+0.60.0 - 2021-04-28
 -------------------
 
 * Update for Twisted 20.3.0

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.60.0'
+VERSION = '0.61.0'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
Scope
=====

This add support for calling cleanup based on stacks/layers.

This is used by our chevah/server tests in which we have a shared service layer that is used by multiple tests.


Changes
=======

Add a simple enterCleanup/exitCleanup APi for cleanup layers.

As a drive-by change I have updated the IPv4 and IPv6 mocks to return an IP address and not a hostname.


How to try and test the changes
===============================

reviewers: @danuker 

check that changes make sense and they can be used in chevah/server