### PR TITLE
[#5687] assertEqual checks Unicode vs. strings in collections

### DIFF
--- a/chevah/compat/nt_filesystem.py
+++ b/chevah/compat/nt_filesystem.py
@@ -130,7 +130,7 @@ class NTFilesystem(PosixFilesystemBase):
         else:
             # Default tempfile.gettempdir() return path with short names,
             # due to win32api.GetTempPath().
-            return self._pathSplitRecursive(
+            return self.getSegmentsFromRealPath(
                 win32api.GetLongPathName(win32api.GetTempPath()))
 
     @property
@@ -261,6 +261,8 @@ class NTFilesystem(PosixFilesystemBase):
 
         if path is None or path == u'':
             return segments
+
+        path = text_type(path)
 
         target = os.path.abspath(path.replace('/', '\\')).lower()
         for virtual_segments, real_path in self._avatar.virtual_folders:

--- a/chevah/compat/nt_service.py
+++ b/chevah/compat/nt_service.py
@@ -81,7 +81,7 @@ class ChevahNTService(win32serviceutil.ServiceFramework, object):
         try:
             # Start everything up
             self.ReportServiceStatus(win32service.SERVICE_RUNNING)
-            self.info('Service started.')
+            self.info(u'Service started.')
 
             # After start this thread execution will be blocked.
             self.start()

--- a/chevah/compat/posix_filesystem.py
+++ b/chevah/compat/posix_filesystem.py
@@ -197,7 +197,7 @@ class PosixFilesystemBase(object):
         '''See `ILocalFilesystem`.'''
         import tempfile
         temporary_folder = tempfile.gettempdir()
-        return self._pathSplitRecursive(temporary_folder)
+        return self.getSegmentsFromRealPath(temporary_folder)
 
     def getRealPathFromSegments(self, segments, include_virtual=True):
         '''See `ILocalFilesystem`.'''

--- a/chevah/compat/testing/testcase.py
+++ b/chevah/compat/testing/testcase.py
@@ -1109,6 +1109,30 @@ class ChevahTestCase(TwistedTestCase, AssertionMixin):
 
         return context.exception
 
+    def assertSequenceEqual(self, first, second, msg, seq_type):
+        super(ChevahTestCase, self).assertSequenceEqual(
+            first, second, msg, seq_type)
+
+        for first_element, second_element in zip(first, second):
+            self.assertEqual(first_element, second_element)
+
+    def assertDictEqual(self, first, second, msg):
+        super(ChevahTestCase, self).assertDictEqual(first, second, msg)
+
+        first_keys = sorted(first.keys())
+        second_keys = sorted(second.keys())
+        first_values = [first[key] for key in first_keys]
+        second_values = [second[key] for key in second_keys]
+        self.assertSequenceEqual(first_keys, second_keys, msg, list)
+        self.assertSequenceEqual(first_values, second_values, msg, list)
+
+    def assertSetEqual(self, first, second, msg):
+        super(ChevahTestCase, self).assertSetEqual(first, second, msg)
+
+        first_elements = sorted(first)
+        second_elements = sorted(second)
+        self.assertSequenceEqual(first_elements, second_elements, msg, list)
+
     def _baseAssertEqual(self, first, second, msg=None):
         """
         Update to stdlib to make sure we don't compare str with unicode.

--- a/chevah/compat/tests/normal/testing/test_assertion.py
+++ b/chevah/compat/tests/normal/testing/test_assertion.py
@@ -187,3 +187,87 @@ class TestAssertionMixin(ChevahTestCase):
             "Element counts were not equal:",
             exception.args[0],
             )
+
+    def test_assertEqual_unicode_vs_bytestring_in_list(self):
+        """
+        Fails with AssertionError when asserting that lists containing
+        a Unicode string vs. a bytestring are equal.
+        """
+
+        unicode_list = [u'text']
+        bytes_list = [b'text']
+        with self.assertRaises(AssertionError) as context:
+            self.assertEqual(unicode_list, bytes_list)
+
+        self.assertEqual('First is unicode while second is str for "text".',
+                         context.exception.message)
+
+    def test_assertEqual_unicode_vs_bytestring_in_nested_list(self):
+        """
+        Fails with AssertionError when asserting that nested lists containing
+        a Unicode string vs. a bytestring are equal.
+        """
+
+        unicode_list = [[u'text']]
+        bytes_list = [[b'text']]
+        with self.assertRaises(AssertionError) as context:
+            self.assertEqual(unicode_list, bytes_list)
+
+        self.assertEqual('First is unicode while second is str for "text".',
+                         context.exception.message)
+
+    def test_assertEqual_unicode_vs_bytestring_in_tuple(self):
+        """
+        Fails with AssertionError when asserting that tuples containing
+        a Unicode string vs. a bytestring are equal.
+        """
+
+        unicode_tuple = (u'text',)
+        bytes_tuple = (b'text',)
+        with self.assertRaises(AssertionError) as context:
+            self.assertEqual(unicode_tuple, bytes_tuple)
+
+        self.assertEqual('First is unicode while second is str for "text".',
+                         context.exception.message)
+
+    def test_assertEqual_unicode_vs_bytestring_in_set(self):
+        """
+        Fails with AssertionError when asserting that sets containing
+        a Unicode string vs. a bytestring are equal.
+        """
+
+        unicode_set = set([u'text'])
+        bytes_set = set([b'text'])
+        with self.assertRaises(AssertionError) as context:
+            self.assertEqual(unicode_set, bytes_set)
+
+        self.assertEqual('First is unicode while second is str for "text".',
+                         context.exception.message)
+
+    def test_assertEqual_unicode_vs_bytestring_in_dict_keys(self):
+        """
+        Fails with AssertionError when asserting that lists containing
+        a Unicode string vs. a bytestring are equal.
+        """
+
+        unicode_dict = {u'key': 'value'}
+        bytes_dict = {b'key': 'value'}
+        with self.assertRaises(AssertionError) as context:
+            self.assertEqual(unicode_dict, bytes_dict)
+
+        self.assertEqual('First is unicode while second is str for "key".',
+                         context.exception.message)
+
+    def test_assertEqual_unicode_vs_bytestring_in_dict_values(self):
+        """
+        Fails with AssertionError when asserting that lists containing
+        a Unicode string vs. a bytestring are equal.
+        """
+
+        unicode_dict = {'key': u'value'}
+        bytes_dict = {'key': b'value'}
+        with self.assertRaises(AssertionError) as context:
+            self.assertEqual(unicode_dict, bytes_dict)
+
+        self.assertEqual('First is unicode while second is str for "value".',
+                         context.exception.message)

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -1,6 +1,11 @@
 Release notes for chevah.compat
 ===============================
 
+0.62.0 - 2021-07-22
+-------------------
+
+* `ChevahTestCase.assertEqual` now checks inside collections
+  for Unicode vs. bytestrings.
 
 0.61.0 - 2021-06-28
 -------------------

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.61.0'
+VERSION = '0.62.0'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
Scope
=====

`ChevahTestCase.assertEqual` now goes inside dicts, lists, tuples, and sets to differentiate Unicode vs. raw string objects.

Changes
=======

Added behavior to `chevah/compat/testing/testcase.py`.

Overrode `unittest` methods named `assertSequenceEqual`, `assertSetEqual`, and `assertDictEqual`.

As a drive-by found a bug where `temp_segments` would return raw strings and not Unicode ones.


How to try and test the changes
===============================

reviewers: @adiroiban 

Use assertEquals in various ways.

This PR should have a counterpart in `chevah/server` before merging, which fixes the tests broken (or bugs discovered) by the `compat` changes.
