### PR TITLE
Test all supported Linux distributions.

### DIFF
--- a/.github/workflows/bare.yml
+++ b/.github/workflows/bare.yml
@@ -6,7 +6,8 @@
 #
 # When running a tmate debug session you might need to increase the
 # timeout-minutes for each build.
-name: GitHub-CI
+
+name: Bare
 
 on:
   push:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,6 +41,7 @@ jobs:
           - amazonlinux:2018.03
           - amazonlinux:2
           - centos:5.11
+          - centos:6.10
           - centos:7
           - centos:8.2.2004
           - centos:8
@@ -74,6 +75,12 @@ jobs:
         cd bin.chevah.com\:20443/third-party-stuff/centos5/endpoint/
         rpm -i local-perl-*.rpm
         rpm -i --nodeps git{-core,}-2.5.0-1.ep.x86_64.rpm
+
+    - name: CentOS 6.10 setup
+      if: matrix.container == 'centos:6.10'
+      run: |
+        sed -i s/^mirrorlist=/#mirrorlist=/ /etc/yum.repos.d/*.repo
+        sed -i s@^#baseurl=http://mirror.centos.org/\$contentdir/\$releasever/@baseurl=https://vault.centos.org/6.10/@ /etc/yum.repos.d/*.repo
 
     # OpenSSL got updated in 8.3 from 1.1.1c to 1.1.1g.
     - name: CentOS 8.2 setup

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,6 +45,8 @@ jobs:
           - centos:7
           - centos:8.2.2004
           - centos:8
+          - ubuntu:14.04
+          - ubuntu:16.04
 
     # ubuntu-latest is GitHub's newest well-suported Linux distro.
     runs-on: ubuntu-latest
@@ -57,7 +59,7 @@ jobs:
       if: startsWith(matrix.container, 'alpine')
       run: |
         apk upgrade -U
-        apk add git bash libffi shadow sudo curl
+        apk add git bash shadow sudo curl
 
     # Final CentOS 5 version is used to build the generic Linux package.
     - name: CentOS 5.11 setup
@@ -94,6 +96,13 @@ jobs:
     - name: Yum-based setup
       if: startsWith(matrix.container, 'centos') || startsWith(matrix.container, 'amazon')
       run: yum -y install git tar which sudo
+
+    - name: Ubuntu setup
+      if: startsWith(matrix.container, 'ubuntu')
+      run: |
+        apt update
+        apt dist-upgrade -y
+        apt install -y git curl
 
     # On a Docker container, everything runs as root by default.
     - name: Chevah user setup

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,8 @@
 # GitHub actions to test chevah-compat under Docker.
 #
 
-name: GitHub-CI-Docker
+
+name: Docker
 
 
 on:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,6 +22,7 @@ concurrency:
 
 
 env:
+  CHEVAH_REPO: compat
   USER: chevah
   CHEVAH_CONTAINER: yes
 
@@ -39,6 +40,7 @@ jobs:
           - alpine:3.14
           - amazonlinux:2018.03
           - amazonlinux:2
+          - centos:5.11
           - centos:7
           - centos:8.2.2004
           - centos:8
@@ -56,6 +58,23 @@ jobs:
         apk upgrade -U
         apk add git bash libffi shadow sudo curl
 
+    # Final CentOS 5 version is used to build the generic Linux package.
+    - name: CentOS 5.11 setup
+      if: matrix.container == 'centos:5.11'
+      run: |
+        sed -i s/^mirrorlist=/#mirrorlist=/ /etc/yum.repos.d/*.repo
+        sed -i s@^#baseurl=http://mirror.centos.org/centos/\$releasever/@baseurl=http://vault.centos.org/5.11/@ /etc/yum.repos.d/*.repo
+        yum -y upgrade
+        # Use https://bin.chevah.com:20443/third-party-stuff/centos5/tuxad/
+        # when tuxad.de dissapears, it has the minimum required stuff.
+        rpm -i http://www.tuxad.de/rpms/tuxad-release-5-1.noarch.rpm
+        yum -y install wget curl gcc44 make m4 automake libtool patch sudo which openssh-clients
+        ln -s /usr/bin/gcc44 /usr/local/bin/gcc
+        wget --mirror --no-parent https://bin.chevah.com:20443/third-party-stuff/centos5/endpoint/
+        cd bin.chevah.com\:20443/third-party-stuff/centos5/endpoint/
+        rpm -i local-perl-*.rpm
+        rpm -i --nodeps git{-core,}-2.5.0-1.ep.x86_64.rpm
+
     # OpenSSL got updated in 8.3 from 1.1.1c to 1.1.1g.
     - name: CentOS 8.2 setup
       if: matrix.container == 'centos:8.2.2004'
@@ -67,32 +86,54 @@ jobs:
       if: startsWith(matrix.container, 'centos') || startsWith(matrix.container, 'amazon')
       run: yum -y install git tar which sudo
 
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+    # On a Docker container, everything runs as root by default.
+    - name: Chevah user setup
+      run: |
+        useradd -g adm -s /bin/bash -m chevah
+        echo '%adm    ALL=NOPASSWD: ALL' > /etc/sudoers
+
+    # GHA's checkout action doesn't work on CentOS 5. This fails on opening a new PR.
+    - name: Clone sources independently
+      run: |
+        cd /home/chevah/
+        git init $CHEVAH_REPO
+        cd $CHEVAH_REPO
+        # Cleanup the repo.
+        git rev-parse --symbolic-full-name --verify --quiet HEAD || true
+        git rev-parse --symbolic-full-name --branches || true
+        git remote remove origin || true
+        # Update repo token.
+        git remote add origin https://github.com/chevah/$CHEVAH_REPO
+        git fetch --no-tags --prune origin
+        # Prepare the code.
+        git clean -f
+        git reset --hard ${{ github.event.after }}
+        git log -1 --format='%H'
 
     - name: Cache build
       uses: actions/cache@v2
+      if: matrix.container != 'centos:5.11'
       with:
         path: |
-          build-compat
+          /home/chevah/$CHEVAH_REPO/build-$CHEVAH-REPO
         key: ${{ runner.os }}-${{ hashFiles('pavement.py') }}-${{ hashFiles('brink.conf') }}-${{ matrix.container }}
 
     - name: Deps
-      run: ./brink.sh deps
+      run: |
+		cd /home/chevah/$CHEVAH_REPO
+		./brink.sh deps
+		chown -R chevah .
 
     - uses: twisted/python-info-action@v1
       with:
         python-path: build-compat/bin/python
 
-    # On a Docker container, everything runs as root by default.
-    - name: Chevah user setup
-      run: |
-        useradd -g adm -s /bin/bash -m chevah
-        echo '%adm    ALL=NOPASSWD: ALL' >> /etc/sudoers
-        chown -R chevah .
-
     - name: Build
-      run: su chevah -c "./brink.sh build"
+      run: |
+		cd /home/chevah/$CHEVAH_REPO
+		su chevah -c "./brink.sh build"
 
     - name: Test
-      run: su chevah -c "./brink.sh test_ci2"
+      run: |
+		cd /home/chevah/$CHEVAH_REPO
+		su chevah -c "./brink.sh test_ci2"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -115,7 +115,7 @@ jobs:
       if: matrix.container != 'centos:5.11'
       with:
         path: |
-          /home/chevah/$CHEVAH_REPO/build-$CHEVAH-REPO
+          /home/chevah/$CHEVAH_REPO/build-$CHEVAH_REPO
         key: ${{ runner.os }}-${{ hashFiles('pavement.py') }}-${{ hashFiles('brink.conf') }}-${{ matrix.container }}
 
     - name: Deps
@@ -126,7 +126,7 @@ jobs:
 
     - uses: twisted/python-info-action@v1
       with:
-        python-path: build-compat/bin/python
+        python-path: /home/chevah/$CHEVAH_REPO/build-$CHEVAH_REPO/bin/python
 
     - name: Build
       run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -80,7 +80,7 @@ jobs:
       if: matrix.container == 'centos:6.10'
       run: |
         sed -i s/^mirrorlist=/#mirrorlist=/ /etc/yum.repos.d/*.repo
-        sed -i s@^#baseurl=http://mirror.centos.org/\$contentdir/\$releasever/@baseurl=https://vault.centos.org/6.10/@ /etc/yum.repos.d/*.repo
+        sed -i s@^#baseurl=http://mirror.centos.org/centos/\$releasever/@baseurl=http://vault.centos.org/6.10/@ /etc/yum.repos.d/*.repo
         yum -y upgrade
 
     # OpenSSL got updated in 8.3 from 1.1.1c to 1.1.1g.
@@ -89,6 +89,7 @@ jobs:
       run: |
         sed -i s/^mirrorlist=/#mirrorlist=/ /etc/yum.repos.d/*.repo
         sed -i s@^#baseurl=http://mirror.centos.org/\$contentdir/\$releasever/@baseurl=https://vault.centos.org/8.2.2004/@ /etc/yum.repos.d/*.repo
+        yum -y upgrade
 
     - name: Yum-based setup
       if: startsWith(matrix.container, 'centos') || startsWith(matrix.container, 'amazon')

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -102,7 +102,7 @@ jobs:
       run: |
         apt update
         apt dist-upgrade -y
-        apt install -y git curl
+        apt install -y git curl sudo
 
     # On a Docker container, everything runs as root by default.
     - name: Chevah user setup

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -120,9 +120,9 @@ jobs:
 
     - name: Deps
       run: |
-		cd /home/chevah/$CHEVAH_REPO
-		./brink.sh deps
-		chown -R chevah .
+        cd /home/chevah/$CHEVAH_REPO
+        ./brink.sh deps
+        chown -R chevah .
 
     - uses: twisted/python-info-action@v1
       with:
@@ -130,10 +130,10 @@ jobs:
 
     - name: Build
       run: |
-		cd /home/chevah/$CHEVAH_REPO
-		su chevah -c "./brink.sh build"
+        cd /home/chevah/$CHEVAH_REPO
+        su chevah -c "./brink.sh build"
 
     - name: Test
       run: |
-		cd /home/chevah/$CHEVAH_REPO
-		su chevah -c "./brink.sh test_ci2"
+        cd /home/chevah/$CHEVAH_REPO
+        su chevah -c "./brink.sh test_ci2"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -101,7 +101,7 @@ jobs:
         useradd -g adm -s /bin/bash -m chevah
         echo '%adm    ALL=NOPASSWD: ALL' > /etc/sudoers
 
-    # GHA's checkout action doesn't work on CentOS 5. This fails on opening a new PR.
+    # GHA's checkout action doesn't work on CentOS 5/6. This fails on opening a new PR.
     - name: Clone sources independently
       run: |
         cd /home/chevah/
@@ -121,7 +121,7 @@ jobs:
 
     - name: Cache build
       uses: actions/cache@v2
-      if: matrix.container != 'centos:5.11'
+      if: matrix.container != 'centos:5.11' && matrix.container != 'centos:6.10'
       with:
         path: |
           /home/chevah/$CHEVAH_REPO/build-$CHEVAH_REPO

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -81,6 +81,7 @@ jobs:
       run: |
         sed -i s/^mirrorlist=/#mirrorlist=/ /etc/yum.repos.d/*.repo
         sed -i s@^#baseurl=http://mirror.centos.org/\$contentdir/\$releasever/@baseurl=https://vault.centos.org/6.10/@ /etc/yum.repos.d/*.repo
+        yum -y upgrade
 
     # OpenSSL got updated in 8.3 from 1.1.1c to 1.1.1g.
     - name: CentOS 8.2 setup

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,7 +4,8 @@
 # Available VMs. Don't use `-latest` as we want to pin an OS version.
 # https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners
 #
-name: GitHub-Lint
+
+name: Lint
 
 on: [push]
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,7 +113,12 @@ jobs:
 
 
   macos-unicode-path:
-    runs-on: macos-latest
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [ macos-10.15, macos-11 ]
+
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,12 +113,7 @@ jobs:
 
 
   macos-unicode-path:
-    runs-on: ${{ matrix.runs-on }}
-    strategy:
-      fail-fast: false
-      matrix:
-        runs-on: [ macos-10.15, macos-11 ]
-
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
 

--- a/README.rst
+++ b/README.rst
@@ -4,11 +4,14 @@ chevah-compat
 .. image:: https://codecov.io/gh/chevah/compat/branch/master/graph/badge.svg
   :target: https://codecov.io/gh/chevah/compat
 
-.. image:: https://github.com/chevah/compat/workflows/GitHub-CI/badge.svg
-  :target: https://github.com/chevah/compat/actions
+.. image:: https://github.com/chevah/compat/workflows/Lint/badge.svg
+  :target: https://github.com/chevah/compat/actions/workflows/lint.yml
 
-.. image:: https://travis-ci.com/chevah/compat.svg?branch=master
-  :target: https://travis-ci.com/github/chevah/compat
+.. image:: https://github.com/chevah/compat/workflows/Bare/badge.svg
+  :target: https://github.com/chevah/compat/actions/workflows/bare.yml
+
+.. image:: https://github.com/chevah/compat/workflows/Docker/badge.svg
+  :target: https://github.com/chevah/compat/actions/workflows/docker.yml
 
 
 Chevah OS Compatibility Layer.

--- a/brink.conf
+++ b/brink.conf
@@ -1,9 +1,9 @@
 BASE_REQUIREMENTS='pip==20.2.4 chevah-brink==0.79.0 paver==1.2.4'
 PYTHON_CONFIGURATION='default@2.7.18.c3cdaec'
 
-BINARY_DIST_URI='https://github.com/chevah/python-package/releases/download'
-# Backup
-# BINARY_DIST_URI='https://bin.chevah.com:20443/production'
+# BINARY_DIST_URI='https://github.com/chevah/python-package/releases/download'
+# The old curl on CentOS 5 has issues with the above.
+BINARY_DIST_URI='https://bin.chevah.com:20443/production'
 # For testing packages, make sure this one is the last uncommented instance:
 # BINARY_DIST_URI='https://bin.chevah.com:20443/testing'
 

--- a/chevah/compat/testing/testcase.py
+++ b/chevah/compat/testing/testcase.py
@@ -872,6 +872,10 @@ def _get_os_version():
         # Arch has no version.
         return 'arch'
 
+    if distro_name in ['centos', 'ol']:
+        # Normalize all RHEL variants.
+        distro_name = 'rhel'
+
     distro_version = ld.version().split('.', 1)[0]
 
     return '%s-%s' % (distro_name, distro_version)

--- a/chevah/compat/tests/elevated/test_system_users.py
+++ b/chevah/compat/tests/elevated/test_system_users.py
@@ -257,8 +257,11 @@ class TestSystemUsers(SystemUsersTestCase):
             )
 
         if self.os_name in ['aix', 'hpux']:
-            # On AIX and HPUX password is here.
+            # On AIX and HPUX password is in the passwd file.
             self.assertTrue(result)
+        elif self.os_version in ['rhel-5']:
+            # Old RHEL/Centos contain has the password in passwd file.
+            self.assertIsTrue(result)
         else:
             # Not here.
             self.assertIsNone(result)
@@ -277,6 +280,10 @@ class TestSystemUsers(SystemUsersTestCase):
         if self.os_name in ['aix', 'hpux']:
             # On AIX and HPUX invalid passwords are not accepted.
             self.assertFalse(result)
+        elif self.os_version in ['rhel-5']:
+            # Old RHEL/Centos contain has the password in passwd file,
+            # and the provided password doesn't match what is in the file.
+            self.assertIsFalse(result)
         else:
             # On all other OSs password is not here.
             self.assertIsNone(result)
@@ -293,6 +300,9 @@ class TestSystemUsers(SystemUsersTestCase):
 
         if self.os_name in ['aix', 'hpux', 'osx', 'freebsd', 'openbsd']:
             # No shadow support.
+            self.assertIsNone(result)
+        elif self.os_version in ['rhel-5']:
+            # No shadow users on old RHEL/Centos container.
             self.assertIsNone(result)
         else:
             self.assertTrue(result)

--- a/pavement.py
+++ b/pavement.py
@@ -58,7 +58,7 @@ if os.name == 'nt':
 # Keep run_packages in sync with setup.py.
 # These are the hard dependencies needed by the library itself.
 RUN_PACKAGES = [
-    'zope.interface==5.4.0.chevah1',
+    'zope.interface==5.4.0+chevah.2',
     'six==1.15.0',
     ]
 
@@ -94,7 +94,7 @@ BUILD_PACKAGES = [
     # Packages required to run the test suite.
     # Never version of nose, hangs on closing some tests
     # due to some thread handling.
-    'nose==1.3.0.chevah12',
+    'nose==1.3.0.chevah13',
     'nose-randomly==1.2.5',
     'mock',
 
@@ -106,7 +106,7 @@ BUILD_PACKAGES = [
     'remote_pdb==1.2.0',
 
     # Twisted is optional, but we have it here for complete tests.
-    'Twisted==20.3.0.chevah1',
+    'Twisted==20.3.0+chevah.3',
     'service_identity==18.1.0',
 
     # We install wmi everywhere even though it is only used on Windows.

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,10 +2,12 @@ Release notes for chevah.compat
 ===============================
 
 
-0.62.1 - 2021-08-08
+0.63.0 - 2021-08-09
 -------------------
 
 * Disable PAM for Alpine.
+* ChevahTestCase.os_version was updated for RHEL, CentOS and Oracle Linux to
+  always return `rhel-N` as the Linux distribution name.
 
 
 0.62.0 - 2021-07-22

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.62.1'
+VERSION = '0.63.0'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
Scope
=====

Test on all OS'es listed as supported at https://www.sftpplus.com/documentation/sftpplus/trial/ (except Windows version other than 2016/2019).

Fix failing tests on CentOS 5 which impede enabling python-package compat tests, see https://github.com/chevah/python-package/pull/151/checks?check_run_id=3278319527

Fixes #117.

Changes
=======

Test on CentOS 5 and 6 under Docker through GHA.

The above requires cloning sources without `actions/checkout`.

On CentOS 5 there was also an issue with the cert for GitHub servers hosting our releases, so I've switched to using bin.chevah.com in `brink.conf` .

Also test on Ubuntu Server 14.04/16.04, while at it.

**Drive-by fixes**:
  * Updated Python modules versions in `pavement.py` to match server repo.


How to try and test the changes
===============================

reviewers: @adiroiban 

Please review changes.

Run the tests.

Fix the tests failing on CentOS 5.