### PR TITLE
[#678] Add absolute path API.

### DIFF
--- a/.github/workflows/bare.yml
+++ b/.github/workflows/bare.yml
@@ -160,7 +160,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ macos-11 ]
+        runs-on: [ macos-12 ]
     runs-on: ${{ matrix.runs-on }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/bare.yml
+++ b/.github/workflows/bare.yml
@@ -184,6 +184,7 @@ jobs:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Public coverage
+      if: ${{ !cancelled() }}
       run: sh ./brink.sh codecov_publish
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/bare.yml
+++ b/.github/workflows/bare.yml
@@ -160,7 +160,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ windows-2019, windows-2022 ]
+        # For now the Windows-2022 VM from Github can't run our build.
+        # To be fixed in a separate PR.
+        runs-on: [ windows-2019 ]
     runs-on: ${{ matrix.runs-on }}
 
     steps:

--- a/.github/workflows/bare.yml
+++ b/.github/workflows/bare.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Deps
       run: ./brink.sh deps
 
-    - uses: twisted/python-info-action@v1
+    - uses: chevah/python-info-action@v1
       with:
         python-path: build-compat/bin/python
 
@@ -64,7 +64,7 @@ jobs:
 
     - name: Tmate debug on failure
       if: failure() && env.TMATE_DEBUG == 'yes'
-      uses: mxschmitt/action-tmate@v3
+      uses: chevah/action-tmate@v3
       with:
         limit-access-to-actor: true
 
@@ -103,7 +103,7 @@ jobs:
 
     - name: Tmate debug on failure
       if: failure() && env.TMATE_DEBUG == 'yes'
-      uses: mxschmitt/action-tmate@v3
+      uses: chevah/action-tmate@v3
       with:
         limit-access-to-actor: true
 
@@ -118,6 +118,7 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [  macos-10.15, macos-11 ]
+    runs-on: ${{ matrix.runs-on }}
     steps:
     - uses: actions/checkout@v2
 
@@ -142,7 +143,7 @@ jobs:
 
     - name: Tmate debug on failure
       if: failure() && env.TMATE_DEBUG == 'yes'
-      uses: mxschmitt/action-tmate@v3
+      uses: chevah/action-tmate@v3
       with:
         limit-access-to-actor: true
 
@@ -156,11 +157,11 @@ jobs:
 
 
   windows:
-    runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
       matrix:
         runs-on: [ windows-2019, windows-2022 ]
+    runs-on: ${{ matrix.runs-on }}
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/bare.yml
+++ b/.github/workflows/bare.yml
@@ -162,7 +162,7 @@ jobs:
       matrix:
         # For now the Windows-2022 VM from Github can't run our build.
         # To be fixed in a separate PR.
-        runs-on: [ windows-2019 ]
+        runs-on: [ windows-2019, windows-2022 ]
     runs-on: ${{ matrix.runs-on }}
 
     steps:

--- a/.github/workflows/bare.yml
+++ b/.github/workflows/bare.yml
@@ -114,7 +114,10 @@ jobs:
 
 
   macos-unicode-path:
-    runs-on: macos-10.15
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [  macos-10.15, macos-11 ]
     steps:
     - uses: actions/checkout@v2
 
@@ -157,7 +160,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ windows-2019, windows-2016 ]
+        runs-on: [ windows-2019, windows-2022 ]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -138,7 +138,7 @@ jobs:
         ./brink.sh deps
         chown -R chevah .
 
-    - uses: twisted/python-info-action@v1
+    - uses: chevah/python-info-action@v1
       with:
         python-path: /home/chevah/$CHEVAH_REPO/build-$CHEVAH_REPO/bin/python
 

--- a/brink.conf
+++ b/brink.conf
@@ -1,9 +1,9 @@
-BASE_REQUIREMENTS='pip==20.2.4 chevah-brink==0.79.0 paver==1.2.4'
-PYTHON_CONFIGURATION='default@2.7.18.ad5a0e1'
+BASE_REQUIREMENTS='pip==20.3.4chevah chevah-brink==0.79.0 paver==1.2.4'
+PYTHON_CONFIGURATION='default@2.7.18.93dc340'
 # For production packages there are 2 options:
 BINARY_DIST_URI='https://github.com/chevah/python-package/releases/download'
 #BINARY_DIST_URI='https://bin.chevah.com:20443/production'
 # For testing packages, make sure this one is the last uncommented instance:
 #BINARY_DIST_URI='https://bin.chevah.com:20443/testing'
-PIP_INDEX='https://bin.chevah.com:20443/pypi/simple'
+PIP_INDEX_URL='https://bin.chevah.com:20443/pypi/simple'
 CHEVAH_BUILD_DIR='build-compat'

--- a/brink.sh
+++ b/brink.sh
@@ -87,7 +87,7 @@ PYTHON_VERSION='not.defined.yet'
 PYTHON_PLATFORM='unknown-os-and-arch'
 PYTHON_NAME='python2.7'
 BINARY_DIST_URI='https://github.com/chevah/python-package/releases/download'
-PIP_INDEX='https://pypi.org/simple'
+PIP_INDEX_URL='https://pypi.org/simple'
 BASE_REQUIREMENTS=''
 
 #
@@ -138,6 +138,10 @@ clean_build() {
     delete_folder ${DIST_FOLDER}
     echo "Removing publish..."
     delete_folder 'publish'
+    echo "Removing node_modules..."
+    delete_folder node_modules
+    echo "Removing web build"
+    delete_folder chevah/server/static/build/
 
     # In some case pip hangs with a build folder in temp and
     # will not continue until it is manually removed.
@@ -258,6 +262,7 @@ update_path_variables() {
     export CHEVAH_OS=${OS}
     export CHEVAH_ARCH=${ARCH}
     export CHEVAH_CACHE=${CACHE_FOLDER}
+    export PIP_INDEX_URL=${PIP_INDEX_URL}
 
 }
 
@@ -315,8 +320,8 @@ pip_install() {
     ${PYTHON_BIN} -m \
         pip install \
             --trusted-host bin.chevah.com \
-            --trusted-host deag.chevah.com \
-            --index-url=$PIP_INDEX \
+            --trusted-host pypi-internal.chevah.com \
+            --index-url=$PIP_INDEX_URL \
             --build=${BUILD_FOLDER}/pip-build \
             $1
 
@@ -809,17 +814,6 @@ detect_os() {
             ;;
         "amd64"|"x86_64")
             ARCH="x64"
-            case "$OS" in
-                win)
-                    # 32bit build on Windows 2016, 64bit otherwise.
-                    # Should work with a l10n pack too (tested with French).
-                    win_ver=$(systeminfo.exe | head -n 3 | tail -n 1 \
-                        | cut -d ":" -f 2)
-                    if [[ "$win_ver" =~ "Microsoft Windows Server 2016" ]]; then
-                        ARCH="x86"
-                    fi
-                    ;;
-            esac
             ;;
         "aarch64")
             ARCH="arm64"

--- a/brink.sh
+++ b/brink.sh
@@ -737,7 +737,6 @@ detect_os() {
                             check_linux_glibc
                         fi
                         set_os_if_not_generic "ubuntu" $os_version_chevah
-                        set_os_if_not_generic "lnx" ""
                         ;;
                     alpine)
                         os_version_raw="$VERSION_ID"

--- a/brink.sh
+++ b/brink.sh
@@ -737,6 +737,7 @@ detect_os() {
                             check_linux_glibc
                         fi
                         set_os_if_not_generic "ubuntu" $os_version_chevah
+                        set_os_if_not_generic "lnx" ""
                         ;;
                     alpine)
                         os_version_raw="$VERSION_ID"

--- a/chevah/compat/interfaces.py
+++ b/chevah/compat/interfaces.py
@@ -516,7 +516,7 @@ class ILocalFilesystem(Interface):
 
     def iterateFolderContent(segments):
         """
-        Return an iterator for the name of each direct child of folder.
+        Return an iterator with the IFileAttributes of each direct child.
         """
 
     def getStatus(segments):

--- a/chevah/compat/interfaces.py
+++ b/chevah/compat/interfaces.py
@@ -419,6 +419,11 @@ class ILocalFilesystem(Interface):
         `path` is a ChevahPath and can be a relative path of the home folder.
         """
 
+    def isAbsolutePath(path):
+        """
+        Return True if path points to an asbolute path.
+        """
+
     def isFile(segments):
         """
         Return True if segments points to a file.

--- a/chevah/compat/nt_filesystem.py
+++ b/chevah/compat/nt_filesystem.py
@@ -127,11 +127,17 @@ class NTFilesystem(PosixFilesystemBase):
         # impersonated account don't have access to it.
         if not isinstance(self._avatar, NTDefaultAvatar):
             return [u'c', u'temp']
+
+        if self.avatar.lock_in_home_folder:
+            # Similar to posix_filesystem
+            temp_path = os.path.join(
+                self.avatar.home_folder_path, '__chevah_test_temp__')
         else:
             # Default tempfile.gettempdir() return path with short names,
             # due to win32api.GetTempPath().
-            return self.getSegmentsFromRealPath(
-                win32api.GetLongPathName(win32api.GetTempPath()))
+            temp_path = win32api.GetLongPathName(win32api.GetTempPath())
+
+        return self.getSegmentsFromRealPath(temp_path)
 
     @property
     def installation_segments(self):

--- a/chevah/compat/nt_filesystem.py
+++ b/chevah/compat/nt_filesystem.py
@@ -262,9 +262,6 @@ class NTFilesystem(PosixFilesystemBase):
             # We consider it relative.
             return False
 
-        if path.startswith('\\\\'):
-            return True
-
         if len(path) == 2 and path[1] == ':':
             return True
 

--- a/chevah/compat/nt_filesystem.py
+++ b/chevah/compat/nt_filesystem.py
@@ -249,6 +249,9 @@ class NTFilesystem(PosixFilesystemBase):
         More info about Windows paths at:
         https://docs.microsoft.com/en-us/dotnet/standard/io/file-path-formats
         """
+        if not path:
+            return False
+
         if path.startswith('\\\\'):
             return True
 

--- a/chevah/compat/nt_filesystem.py
+++ b/chevah/compat/nt_filesystem.py
@@ -251,8 +251,27 @@ class NTFilesystem(PosixFilesystemBase):
     def isAbsolutePath(self, path):
         """
         See `ILocalFilesystem`.
+
+        More info about Windows paths at:
+        https://docs.microsoft.com/en-us/dotnet/standard/io/file-path-formats
         """
         if path.startswith('\\\\'):
+            return True
+
+        if len(path) == 1:
+            # Single drive.
+            return True
+
+        if path[0] in ['\\', '/']:
+            # Relative path to the current drive.
+            # Windows call it absolute.
+            # We consider it relative.
+            return False
+
+        if path.startswith('\\\\'):
+            return True
+
+        if len(path) == 2 and path[1] == ':':
             return True
 
         return os.path.isabs(path)
@@ -288,6 +307,10 @@ class NTFilesystem(PosixFilesystemBase):
         head = True
 
         if path.startswith('\\\\?\\'):
+            # We have a long UNC and we normalize.
+            path = path[4:]
+
+        if path.startswith('\\\\.\\'):
             # We have a long UNC and we normalize.
             path = path[4:]
 

--- a/chevah/compat/nt_filesystem.py
+++ b/chevah/compat/nt_filesystem.py
@@ -273,6 +273,9 @@ class NTFilesystem(PosixFilesystemBase):
     def _getAbsolutePath(self, path):
         """
         Return the absolute path.
+
+        The stdlib os.path.abspath goes crazy when the current
+        working directory is a drive path (\\\\?\\C:\\some-drive-path)
         """
         return os.path.join(os.getcwd(), os.path.normpath(path))
 

--- a/chevah/compat/nt_filesystem.py
+++ b/chevah/compat/nt_filesystem.py
@@ -248,6 +248,15 @@ class NTFilesystem(PosixFilesystemBase):
             raise OSError(
                 errno.EINVAL, message.encode('utf-8'), path.encode('utf-8'))
 
+    def isAbsolutePath(self, path):
+        """
+        See `ILocalFilesystem`.
+        """
+        if path.startswith('\\\\'):
+            return True
+
+        return os.path.isabs(path)
+
     def getSegmentsFromRealPath(self, path):
         """
         See `ILocalFilesystem`.

--- a/chevah/compat/posix_filesystem.py
+++ b/chevah/compat/posix_filesystem.py
@@ -353,6 +353,10 @@ class PosixFilesystemBase(object):
 
         return absolute_path
 
+    def isAbsolutePath(self, path):
+        '''See `ILocalFilesystem`.'''
+        return os.path.isabs(path)
+
     def isFolder(self, segments):
         '''See `ILocalFilesystem`.'''
         try:

--- a/chevah/compat/posix_filesystem.py
+++ b/chevah/compat/posix_filesystem.py
@@ -195,8 +195,13 @@ class PosixFilesystemBase(object):
     @property
     def temp_segments(self):
         '''See `ILocalFilesystem`.'''
-        import tempfile
-        temporary_folder = tempfile.gettempdir()
+        if self.avatar.lock_in_home_folder:
+            temporary_folder = os.path.join(
+                self.avatar.home_folder_path, '__chevah_test_temp__')
+        else:
+            # Go with general temporary directory.
+            import tempfile
+            temporary_folder = tempfile.gettempdir()
         return self.getSegmentsFromRealPath(temporary_folder)
 
     def getRealPathFromSegments(self, segments, include_virtual=True):

--- a/chevah/compat/testing/conditionals.py
+++ b/chevah/compat/testing/conditionals.py
@@ -106,7 +106,7 @@ def onOSVersion(versions):
         return process_capabilities.os_version not in versions
 
     return skipOnCondition(
-        check_os_name, 'OS version "%s" not available.' % versions)
+        check_os_version, 'OS version "%s" not available.' % versions)
 
 
 def onCIName(name):

--- a/chevah/compat/testing/conditionals.py
+++ b/chevah/compat/testing/conditionals.py
@@ -16,6 +16,19 @@ from chevah.compat import process_capabilities
 from chevah.compat.testing.testcase import ChevahTestCase
 
 
+_SUPPORTED_OS_FAMILIES = [
+    'posix',
+    'nt',
+    ]
+
+_SUPPORTED_OS_NAMES = [
+    'linux',
+    'windows',
+    'aix',
+    'osx',
+    ]
+
+
 def skipOnCondition(callback, message):
     """
     Helper to decorate skip class or methods based on callback results.
@@ -55,8 +68,11 @@ def onOSFamily(family):
     """
     Run test only if current os is from `family`.
     """
+    if family not in _SUPPORTED_OS_FAMILIES:
+        raise AssertionError('Unknow os family: %s' % (family,))
+
     def check_os_family():
-        return process_capabilities.os_family != family.lower()
+        return process_capabilities.os_family != family
 
     return skipOnCondition(
         check_os_family, 'OS family "%s" not available.' % family)
@@ -71,11 +87,26 @@ def onOSName(name):
     else:
         name = [item.lower() for item in name]
 
+    for os_name in name:
+        if os_name not in _SUPPORTED_OS_NAMES:
+            raise AssertionError('Unknow os name: %s' % (os_name,))
+
     def check_os_name():
         return process_capabilities.os_name not in name
 
     return skipOnCondition(
         check_os_name, 'OS name "%s" not available.' % name)
+
+
+def onOSVersion(versions):
+    """
+    Run test only if current os vesrsion or is in one from `versions` list.
+    """
+    def check_os_version():
+        return process_capabilities.os_version not in versions
+
+    return skipOnCondition(
+        check_os_name, 'OS version "%s" not available.' % versions)
 
 
 def onCIName(name):

--- a/chevah/compat/testing/mockup.py
+++ b/chevah/compat/testing/mockup.py
@@ -59,9 +59,15 @@ class SanitizeNameMixin(object):
         """
         Return name sanitized for current OS.
         """
+        from chevah.compat.testing.testcase import ChevahTestCase
         os_name = process_capabilities.os_name
+        os_version = ChevahTestCase.os_version
         if os_name in ['aix', 'hpux', 'freebsd', 'openbsd']:
             return _sanitize_name_legacy_unix(name).decode('utf-8')
+        elif os_version in ['osx-10.16']:
+            # It looks like macOS 11 can't handle full Unix group names.
+            macosname = _sanitize_name_legacy_unix(name).decode('utf-8')
+            return macosname.replace('_', 'Z')
         elif os_name == 'windows':
             return _sanitize_name_windows(name).decode('utf-8')
 

--- a/chevah/compat/tests/elevated/__init__.py
+++ b/chevah/compat/tests/elevated/__init__.py
@@ -27,6 +27,12 @@ def runElevatedTest():
         # and since is not a supported OS we skip the tests.
         return False
 
+    if CompatTestCase.os_version != 'osx-10.15':
+        # On latest macOS we have issues creating the groups.
+        # We kind of stop supporting macOS for system users,
+        # so we don't care about elevated tests.
+        return False
+
     if not process_capabilities.impersonate_local_account:
         return False
 

--- a/chevah/compat/tests/elevated/test_system_users.py
+++ b/chevah/compat/tests/elevated/test_system_users.py
@@ -439,7 +439,7 @@ class TestSystemUsers(SystemUsersTestCase):
         """
         Check getGroupForUser on Unix.
         """
-        if os.name != 'posix':
+        if self.os_name != 'linux':
             raise self.skipTest()
 
         groups = [u'other-non-group', TEST_ACCOUNT_GROUP, u'here-we-go']

--- a/chevah/compat/tests/normal/test_filesystem.py
+++ b/chevah/compat/tests/normal/test_filesystem.py
@@ -2044,6 +2044,8 @@ class LocalFilesystemNTMixin(object):
         """
         # Traditional DOS paths.
         self.assertIsTrue(
+            self.filesystem.isAbsolutePath('c'))
+        self.assertIsTrue(
             self.filesystem.isAbsolutePath('c:'))
         self.assertIsTrue(
             self.filesystem.isAbsolutePath('c:/'))
@@ -2120,8 +2122,10 @@ class TestLocalFilesystemNTnonDevicePath(
         if cls.os_family != 'nt':
             raise cls.skipTest('Only on Windows.')
         cls._prev_os_getcwd = os.getcwd()
-        if cls._prev_os_getcwd.startswith('\\\\'):
+        if cls._prev_os_getcwd.startswith('\\\\'):  # noqa:cover
             # We have a device path, so force using a non-device path
+            # Most of the time, tests are executed from a process
+            # that already has a DOS path and not a device path.
             os.chdir(cls._prev_os_getcwd[4:])
         super(TestLocalFilesystemNTnonDevicePath, cls).setUpClass()
 

--- a/chevah/compat/tests/normal/test_filesystem.py
+++ b/chevah/compat/tests/normal/test_filesystem.py
@@ -101,7 +101,7 @@ class FilesystemTestingHelpers(object):
 
 class FilesystemTestMixin(FilesystemTestingHelpers):
     """
-    Common tests for filesystem for all OSes..
+    Common tests for filesystem for all OSes.
     """
 
     def test_getSegments_upper_paths(self):

--- a/chevah/compat/tests/normal/test_filesystem.py
+++ b/chevah/compat/tests/normal/test_filesystem.py
@@ -2404,16 +2404,16 @@ class TestLocalFilesystemUnlocked(CompatTestCase, FilesystemTestMixin):
         """
         result = self.unlocked_filesystem.iterateFolderContent([])
         # Make sure we have an iterator and not an iterable.
-        content = [next(result)] + list(result)
+        members = [next(result)] + list(result)
 
         # All windows should contain drive C.
-        self.assertContains('C', content)
+        self.assertContains('C', [c.name for c in members])
 
         parent_content = self.unlocked_filesystem.iterateFolderContent(['..'])
-        self.assertEqual(content, list(parent_content))
+        self.assertEqual(members, list(parent_content))
 
         parent_content = self.unlocked_filesystem.iterateFolderContent(['.'])
-        self.assertEqual(content, list(parent_content))
+        self.assertEqual(members, list(parent_content))
 
     # This test applies only for windows as the root folder is a meta
     # folder containing the Local drives.

--- a/chevah/compat/tests/normal/test_filesystem.py
+++ b/chevah/compat/tests/normal/test_filesystem.py
@@ -2084,6 +2084,9 @@ class LocalFilesystemNTMixin(object):
         self.assertIsTrue(self.filesystem.isAbsolutePath(
             '\\\\Server\\Share'))
 
+        # Empty path is not absolute.
+        self.assertIsFalse(self.filesystem.isAbsolutePath(''))
+
         # Using forward slashes will handled it as relative path.
         self.assertIsFalse(self.filesystem.isAbsolutePath(
             '//system07/share-name'))

--- a/chevah/compat/tests/normal/test_filesystem.py
+++ b/chevah/compat/tests/normal/test_filesystem.py
@@ -1911,6 +1911,16 @@ class LocalFilesystemNTMixin(object):
     Shared tests for Windows path handling in an unlocked filesystem.
     """
 
+    def test_temp_segments(self):
+        """
+        The temporary segments are the default Windows OS segments
+        """
+        result = self.filesystem.temp_segments
+
+        # We assume that all tests run from drive C
+        # and were we check that the temp segments are for an absolute path.
+        self.assertEqual('C', result[0])
+
     def test_rename_file_read_only(self):
         """
         On Windows, it will rename the file even if it has the read only
@@ -2136,16 +2146,6 @@ class TestLocalFilesystemNTnonDevicePath(
         finally:
             os.chdir(cls._prev_os_getcwd)
 
-    def test_temp_segments(self):
-        """
-        The temporary segments are the default Windows OS segments
-        """
-        result = self.filesystem.temp_segments
-
-        # We assume that all tests run from drive C
-        # and were we check that the temp segments are for an absolute path.
-        self.assertEqual('c', result[0])
-
 
 class TestLocalFilesystemNTDevicePath(
         DefaultFilesystemTestCase, LocalFilesystemNTMixin):
@@ -2175,17 +2175,6 @@ class TestLocalFilesystemNTDevicePath(
             super(TestLocalFilesystemNTDevicePath, cls).tearDownClass()
         finally:
             os.chdir(cls._prev_os_getcwd)
-
-    def test_temp_segments(self):
-        """
-        The temporary segments are the default Windows OS segments
-        """
-        result = self.filesystem.temp_segments
-
-        # We assume that all tests run from drive C
-        # and were we check that the temp segments are for an absolute path.
-        self.assertEqual('UNC', result[0])
-        self.assertEqual('c', result[1])
 
 
 @conditionals.onOSFamily('posix')

--- a/chevah/compat/tests/normal/test_filesystem.py
+++ b/chevah/compat/tests/normal/test_filesystem.py
@@ -1908,7 +1908,7 @@ class TestLocalFilesystem(DefaultFilesystemTestCase):
 
 class LocalFilesystemNTMixin(object):
     """
-    Shared tests for Windows path handling.
+    Shared tests for Windows path handling in an unlocked filesystem.
     """
 
     def test_rename_file_read_only(self):
@@ -2136,6 +2136,16 @@ class TestLocalFilesystemNTnonDevicePath(
         finally:
             os.chdir(cls._prev_os_getcwd)
 
+    def test_temp_segments(self):
+        """
+        The temporary segments are the default Windows OS segments
+        """
+        result = self.filesystem.temp_segments
+
+        # We assume that all tests run from drive C
+        # and were we check that the temp segments are for an absolute path.
+        self.assertEqual('c', result[0])
+
 
 class TestLocalFilesystemNTDevicePath(
         DefaultFilesystemTestCase, LocalFilesystemNTMixin):
@@ -2165,6 +2175,17 @@ class TestLocalFilesystemNTDevicePath(
             super(TestLocalFilesystemNTDevicePath, cls).tearDownClass()
         finally:
             os.chdir(cls._prev_os_getcwd)
+
+    def test_temp_segments(self):
+        """
+        The temporary segments are the default Windows OS segments
+        """
+        result = self.filesystem.temp_segments
+
+        # We assume that all tests run from drive C
+        # and were we check that the temp segments are for an absolute path.
+        self.assertEqual('UNC', result[0])
+        self.assertEqual('c', result[1])
 
 
 @conditionals.onOSFamily('posix')
@@ -2759,6 +2780,13 @@ class TestLocalFilesystemLocked(CompatTestCase, FilesystemTestMixin):
 
         with self.assertRaises(CompatError):
             self.locked_filesystem.getSegmentsFromRealPath('..\\..\\outside')
+
+    def test_temp_segments(self):
+        """
+        The temporary segments are inside the locked path.
+        """
+        result = self.locked_filesystem.temp_segments
+        self.assertEqual(['__chevah_test_temp__'], result)
 
     @conditionals.onCapability('symbolic_link', True)
     def test_exists_outside_link(self):

--- a/chevah/compat/tests/normal/testing/test_testcase.py
+++ b/chevah/compat/tests/normal/testing/test_testcase.py
@@ -666,7 +666,7 @@ class TestChevahTestCase(ChevahTestCase):
         """
         raise AssertionError('Should not be called.')
 
-    @conditionals.onOSFamily('posiX')
+    @conditionals.onOSFamily('posix')
     def test_onOSFamily_posix(self):
         """
         Run test only on posix.
@@ -674,7 +674,7 @@ class TestChevahTestCase(ChevahTestCase):
         if os.name != 'posix':
             raise AssertionError('This should be called only on posix.')
 
-    @conditionals.onOSFamily('Nt')
+    @conditionals.onOSFamily('nt')
     def test_onOSFamily_nt(self):
         """
         Run test only on NT. This is the complement of previous test.
@@ -682,7 +682,7 @@ class TestChevahTestCase(ChevahTestCase):
         if os.name != 'nt':
             raise AssertionError('This should be called only on NT.')
 
-    @conditionals.onOSName('linuX')
+    @conditionals.onOSName('linux')
     def test_onOSName_linux(self):
         """
         Run test only on Linux.
@@ -690,7 +690,7 @@ class TestChevahTestCase(ChevahTestCase):
         if not sys.platform.startswith('linux'):
             raise AssertionError('This should be called only on Linux.')
 
-    @conditionals.onOSName(['Linux', 'aix'])
+    @conditionals.onOSName(['linux', 'aix'])
     def test_onOSName_linux_aix(self):
         """
         Run test only on Linux and AIX.
@@ -857,7 +857,7 @@ class TestChevahTestCase(ChevahTestCase):
         self.assertEqual([True], self.top_stack_called)
 
 
-@conditionals.onOSFamily('posiX')
+@conditionals.onOSFamily('posix')
 class TestClassConditionalsPosix(ChevahTestCase):
     """
     Conditionals also work on classes.

--- a/chevah/compat/unix_users.py
+++ b/chevah/compat/unix_users.py
@@ -415,8 +415,9 @@ class UnixUsers(CompatUsers):
             try:
                 from pam import authenticate as pam_authenticate
                 self._pam_authenticate = pam_authenticate
-            except ImportError:
+            except (ImportError, AssertionError):
                 # We set this to false to not check it again.
+                # On macOS we get AssertionError.
                 self._pam_authenticate = False
 
         return self._pam_authenticate

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,13 @@ Release notes for chevah.compat
 ===============================
 
 
+0.64.1 - 2022-05-26
+-------------------
+
+* Fix iterateFolderContent on Windows for unlocked accounts when listing the
+  root.
+
+
 0.64.0 - 2022-05-02
 -------------------
 

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,11 +2,11 @@ Release notes for chevah.compat
 ===============================
 
 
-unreleased
+0.64.3 - 2022-09-14
 -------------------
 
 
-* `temp_segments` on Windows now works for locked filesyste,
+* `temp_segments` on Windows now works for locked filesystems,
 
 
 0.64.2 - 2022-09-14

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,12 @@ Release notes for chevah.compat
 ===============================
 
 
+0.64.2 - 2022-09-14
+-------------------
+
+* `isAbsolutePath` returns False for an empty string instead of raising an error.
+
+
 0.64.1 - 2022-05-26
 -------------------
 

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,14 @@ Release notes for chevah.compat
 ===============================
 
 
+0.64.0 - 2022-05-02
+-------------------
+
+* Add `ILocalFilesystem.isAbsolutePath` API.
+* Add `conditionals.onOSVersion` helper.
+* Disable PAM for macOS.
+
+
 0.63.0 - 2021-08-09
 -------------------
 

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -8,6 +8,11 @@ Release notes for chevah.compat
 * Add `ILocalFilesystem.isAbsolutePath` API.
 * Add `conditionals.onOSVersion` helper.
 * Disable PAM for macOS.
+* Fix handling for path on Windows when the current working directory is a
+  drive path \\?\c:\some\drive-path
+* Make sure the temporary path for the `LocalTestFilesystem` is always
+  accessible event for avatar that are locked inside their home folder
+  and don't have access to the global temporary directory.
 
 
 0.63.0 - 2021-08-09

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,13 @@ Release notes for chevah.compat
 ===============================
 
 
+unreleased
+-------------------
+
+
+* `temp_segments` on Windows now works for locked filesyste,
+
+
 0.64.2 - 2022-09-14
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.63.0'
+VERSION = '0.64.0'
 
 
 class PublishCommand(Command):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.64.2'
+VERSION = '0.64.3'
 
 
 class PublishCommand(Command):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.64.1'
+VERSION = '0.64.2'
 
 
 class PublishCommand(Command):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.64.0'
+VERSION = '0.64.1'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
Scope
=====

Fixes #678 
Fixes #677 
Fixes #115 

We need a custom API to detect if a path is absolute.

And as part of this PR, we might need to add support for handling windows shares as segments.


Changes
=======

As a drive-by I have updated brink.sh and conf.
Also updated the GitHub actions workflow with latest oses.



How to try and test the changes
===============================

reviewers: @danuker 

check that changes make sense.