### PR TITLE
[#680] Add support to get groups for users from secondary domain

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -83,8 +83,8 @@ jobs:
         sed -i s@^#baseurl=http://mirror.centos.org/\$contentdir/\$releasever/@baseurl=https://vault.centos.org/8.2.2004/@ /etc/yum.repos.d/*.repo
         yum -y upgrade
 
-    - name: Amazon Linux 2022 setup
-      if: matrix.container == 'amazonlinux:2022'
+    - name: Install libxcrypt-compat on latest distros
+      if: matrix.container == 'amazonlinux:2022' || matrix.container == 'rockylinux:9'
       run: yum -y install libxcrypt-compat
 
     - name: Yum-based setup

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,7 +38,8 @@ jobs:
       fail-fast: false
       matrix:
         container:
-          - alpine:3.14
+          - alpine:3.12
+          - alpine:3.16
           - amazonlinux:2018.03
           - amazonlinux:2
           - amazonlinux:2022
@@ -49,8 +50,9 @@ jobs:
           - centos:7
           - centos:8.2.2004
           - oraclelinux:8
+          - rockylinux:9
           - ubuntu:14.04
-          - ubuntu:16.04
+          - ubuntu:18.04
           - ubuntu:22.04
 
     # ubuntu-latest is GitHub's newest well-suported Linux distro.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -88,7 +88,7 @@ jobs:
       run: yum -y install libxcrypt-compat
 
     - name: Yum-based setup
-      if: startsWith(matrix.container, 'centos') || startsWith(matrix.container, 'amazon') || startsWith(matrix.container, 'oracle')
+      if: startsWith(matrix.container, 'centos') || startsWith(matrix.container, 'amazon') || startsWith(matrix.container, 'oracle') || startsWith(matrix.container, 'rocky')
       run: yum -y install git tar which sudo
 
     - name: Ubuntu setup

--- a/brink.conf
+++ b/brink.conf
@@ -1,5 +1,5 @@
 BASE_REQUIREMENTS='pip==20.3.4chevah chevah-brink==0.79.0 paver==1.2.4'
-PYTHON_CONFIGURATION='default@2.7.18.93dc340'
+PYTHON_CONFIGURATION='default@2.7.18.90dc4a6'
 # For production packages there are 2 options:
 BINARY_DIST_URI='https://github.com/chevah/python-package/releases/download'
 #BINARY_DIST_URI='https://bin.chevah.com:20443/production'

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -1,6 +1,11 @@
 Release notes for chevah.compat
 ===============================
 
+0.64.4 - 2022-10-17
+-------------------
+
+* The `getGroupForUser` was fixed to work with secondary domains.
+
 
 0.64.3 - 2022-09-14
 -------------------

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.64.3'
+VERSION = '0.64.4'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
Scope
=====

Authentication doesn't fully work for users from a secondary domain.

The credentials are validated, but then getting the groups fails.


Changes
=======

Run the group opration in impersonation mode as the newly authenticated user.

**Drive-by changes**:
  * Updated brink stuff from `python-package` repo, bringing support for more Alpine versions and RHEL 9.
  * Extended the list of tested distros accordingly.


How to try and test the changes
===============================

reviewers: @danuker 

FYI
