### PR TITLE
[#682] Don't lock the file when open for reading.

### DIFF
--- a/chevah/compat/tests/normal/test_filesystem.py
+++ b/chevah/compat/tests/normal/test_filesystem.py
@@ -1715,6 +1715,25 @@ class TestLocalFilesystem(DefaultFilesystemTestCase):
             if a_file:
                 a_file.close()
 
+    def test_openFileForReading_no_delete_lock(self):
+        """
+        A file opened only for reading will not be locked for delete
+        operations.
+        """
+        _, segments = mk.fs.makePathInTemp()
+        mk.fs.writeFileContent(segments=segments, content='something-\N{sun}')
+        a_file = None
+        try:
+            a_file = self.filesystem.openFileForReading(segments)
+
+            self.filesystem.deleteFile(segments)
+
+            content = a_file.read(100)
+            self.assertEqual(b'something-\xe2\x98\x89', content)
+        finally:
+            if a_file:
+                a_file.close()
+
     def test_openFileForWriting_ascii(self):
         """
         Check opening a file for writing in plain/ascii/str mode.

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -1,6 +1,13 @@
 Release notes for chevah.compat
 ===============================
 
+0.65.0 - 2022-12-05
+-------------------
+
+* Don't lock the file on Windows when opened for reading.
+  This is valid for both `openForReading`` method and for the generic
+  `open` method.
+
 
 0.64.3 - 2022-09-14
 -------------------

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.64.3'
+VERSION = '0.65.0'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
Scope
=====

Fixes #682

This tries to get the same behaviour over linux and Windows when opening a file for reading.

The default Python code locks the file on Windows, but the file is not locked on Linux.

Changes
=======

Implement custom Windows open code.


How to try and test the changes
===============================

reviewers: @danuker 

Check that changes make sense

I will create a separate PR for chevah/server in which this will be used and we can do more testing.