### PR TITLE
[#709] Add support for pytest 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -241,6 +241,20 @@ jobs:
         CODECOV_TOKEN: enabled
         USER: runneradmin
 
+    - name: Test pytest
+      run: |
+        ./pythia.sh pytest
+      env:
+        CODECOV_TOKEN: enabled
+        USER: runneradmin
+
+    - name: Test pytest elevated
+      run: |
+        ./pythia.sh pytest src/chevah_compat/tests/elevated/
+      env:
+        CODECOV_TOKEN: enabled
+        USER: runneradmin
+
     - name: Public coverage
       if: ${{ !cancelled() }}
       run: ./pythia.sh codecov_publish

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -119,7 +119,15 @@ jobs:
     - name: Test
       run: ./pythia.sh test_ci2
       env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        CODECOV_TOKEN: enabled
+
+    - name: Test pytest
+      run: |
+        ./pythia.sh pytest
+
+    - name: Test pytest elevated
+      run: |
+        sudo -E ./pythia.sh pytest src/chevah_compat/tests/elevated/
 
     - name: Publish cov
       run: ./pythia.sh codecov_publish
@@ -163,7 +171,7 @@ jobs:
       run: ./pythia.sh test_ci2
       env:
         CHEVAH_BUILD: build-py3-ț
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        CODECOV_TOKEN: enabled
 
     - name: Move build back to to ascii
       run: mv build-py3-ț build-py3
@@ -171,7 +179,7 @@ jobs:
     - name: Publish cov
       run: ./pythia.sh codecov_publish
       env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        CODECOV_TOKEN: enabled
 
     - name: Deps
       run: |
@@ -187,7 +195,15 @@ jobs:
     - name: Test
       run: ./pythia.sh test_ci2
       env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        CODECOV_TOKEN: enabled
+
+    - name: Test pytest
+      run: |
+        ./pythia.sh pytest
+
+    - name: Test pytest elevated
+      run: |
+        sudo -E ./pythia.sh pytest src/chevah_compat/tests/elevated/
 
     - name: Publish cov
       run: ./pythia.sh codecov_publish
@@ -245,14 +261,12 @@ jobs:
       run: |
         ./pythia.sh pytest
       env:
-        CODECOV_TOKEN: enabled
         USER: runneradmin
 
     - name: Test pytest elevated
       run: |
         ./pythia.sh pytest src/chevah_compat/tests/elevated/
       env:
-        CODECOV_TOKEN: enabled
         USER: runneradmin
 
     - name: Public coverage

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,9 +62,21 @@ jobs:
       with:
         limit-access-to-actor: true
 
-    - name: Test
+    - name: Test pynose
       run: |
         ./pythia.sh test_ci2
+      env:
+        CHEVAH_BUILD: build-py3-ț
+
+    - name: Test pytest
+      run: |
+        ./pythia.sh pytest
+      env:
+        CHEVAH_BUILD: build-py3-ț
+
+    - name: Test pytest elevated
+      run: |
+        sudo ./pythia.sh pytest src/chevah_compat/tests/elevated/
       env:
         CHEVAH_BUILD: build-py3-ț
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,7 +76,7 @@ jobs:
 
     - name: Test pytest elevated
       run: |
-        sudo ./pythia.sh pytest src/chevah_compat/tests/elevated/
+        sudo -E ./pythia.sh pytest src/chevah_compat/tests/elevated/
       env:
         CHEVAH_BUILD: build-py3-ț
 

--- a/README.rst
+++ b/README.rst
@@ -4,31 +4,14 @@ chevah-compat
 .. image:: https://codecov.io/gh/chevah/compat/branch/master/graph/badge.svg
   :target: https://codecov.io/gh/chevah/compat
 
-.. image:: https://github.com/chevah/compat/workflows/Lint/badge.svg
-  :target: https://github.com/chevah/compat/actions/workflows/lint.yml
-
-.. image:: https://github.com/chevah/compat/workflows/Bare/badge.svg
-  :target: https://github.com/chevah/compat/actions/workflows/bare.yml
-
-.. image:: https://github.com/chevah/compat/workflows/Docker/badge.svg
-  :target: https://github.com/chevah/compat/actions/workflows/docker.yml
+.. image:: https://github.com/chevah/compat/workflows/ci/badge.svg
+  :target: https://github.com/chevah/compat/actions/workflows/ci.yml
 
 
-Chevah OS Compatibility Layer.
-
-Depends on:
-
-* pam - for pam authentication
-* arpy - for loading libraries on AIX.
-
-Only Python 2.7 is supported for now.
+Chevah OS Compatibility Layer for Python 3.
 
 Unified interface for working with operating system accounts on Unix
 and Windows, see IOSUsers.
-
-Support for starting Unix daemons.
-
-Importing this module on Windows populates sys.argv with Unicode values.
 
 The unified interface for working with operating system file systems provides:
 

--- a/pavement.py
+++ b/pavement.py
@@ -277,7 +277,7 @@ def test_ci2(args):
 @consume_args
 def pytest(args):
     """
-    Run tests for server side API.
+    Run tests using pytest.
     """
     import sys
 

--- a/pavement.py
+++ b/pavement.py
@@ -275,6 +275,20 @@ def test_ci2(args):
 
 @task
 @consume_args
+def pytest(args):
+    """
+    Run tests for server side API.
+    """
+    import sys
+
+    from pytest import console_main
+
+    sys.argv = ['pytest'] + args
+    sys.exit(console_main())
+
+
+@task
+@consume_args
 def lint(args):
     """
     Check that the source code is ok

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chevah-compat"
-version = "1.2.2"
+version = "1.3.0"
 maintainers = [
     { name = "Adi Roiban", email = "adi.roiban@proatria.com" },
 ]
@@ -44,6 +44,7 @@ dev = [
     "incremental",
     "service-identity==24.2.0",
     "pynose == 1.5.3",
+    "pytest ~= 8.3",
     "coverage ~= 7.5",
     "diff_cover == 9.2.0",
     "codecov == 2.1.12",

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,10 @@
+[pytest]
+minversion = 6.0
+addopts = -ra -q -v --capture=no
+testpaths =
+    src/chevah_compat/tests/normal
+
+filterwarnings =
+    ignore: 'crypt' is deprecated and slated for removal
+    ignore: 'spwd' is deprecated and slated for removal
+

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -1,6 +1,11 @@
 Release notes for chevah.compat
 ===============================
 
+1.3.0 - 2024-12-08
+------------------
+
+* Add support for running tests with `pytest`.
+
 
 1.2.2 - 2024-11-03
 ------------------

--- a/src/chevah_compat/administration.py
+++ b/src/chevah_compat/administration.py
@@ -102,14 +102,16 @@ class OSAdministrationUnix:
 
         # Try to get the group in list of all groups.
         group_found = False
-        for iterator in range(1000):
+        for iterator in range(100):
             if group_found:
                 break
             for group in grp.getgrall():
-                if group[0] == name:
+                if group.gr_name == name:
                     group_found = True
                     break
-            time.sleep(0.1)
+            if not group_found:
+                print(f'Waiting for group "{name}"...')
+                time.sleep(0.1)
 
         if not group_found:
             raise AssertionError(f'Failed to get group from all: {name}')
@@ -123,6 +125,7 @@ class OSAdministrationUnix:
             except KeyError:
                 # Group not ready yet.
                 pass
+            print(f'Waiting for group "{name}" in API...')
             time.sleep(0.1)
 
         raise AssertionError(

--- a/src/chevah_compat/testing/assertion.py
+++ b/src/chevah_compat/testing/assertion.py
@@ -148,7 +148,7 @@ class AssertionMixin:
         """
         Raise AssertionError if target is not empty.
         """
-        if isinstance(target, collections.Iterable):
+        if isinstance(target, collections.abc.Iterable):
             iterator = iter(target)
             try:
                 next(iterator)
@@ -167,7 +167,7 @@ class AssertionMixin:
         """
         Raise AssertionError if target is empty.
         """
-        if isinstance(target, collections.Iterable):
+        if isinstance(target, collections.abc.Iterable):
             try:
                 self.assertIsEmpty(target)
             except AssertionError:

--- a/src/chevah_compat/testing/mockup.py
+++ b/src/chevah_compat/testing/mockup.py
@@ -43,6 +43,8 @@ def _sanitize_name_windows(candidate):
 
 
 class SanitizeNameMixin:
+    __test__ = False
+
     @classmethod
     def sanitizeName(cls, name):
         """

--- a/src/chevah_compat/testing/testcase.py
+++ b/src/chevah_compat/testing/testcase.py
@@ -92,9 +92,7 @@ class TwistedTestCase(TestCase):
         """
         Return true if last test run was successful.
         """
-        if self._outcome.result.errors:
-            return False
-        return True
+        return self._outcome.success
 
     def tearDown(self):
         try:
@@ -993,7 +991,7 @@ class ChevahTestCase(TwistedTestCase, AssertionMixin):
         threads = threading.enumerate()
         if len(threads) > 1:
             for thread in threads:
-                thread_name = thread.getName()
+                thread_name = thread.name
                 if self._isExceptedThread(thread_name):
                     continue
                 self._teardown_errors.append(

--- a/src/chevah_compat/tests/conftest.py
+++ b/src/chevah_compat/tests/conftest.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2024 Adi Roiban.
+# See LICENSE for details.
+"""
+Fixtures for pytest run mode.
+"""
+
+import pytest
+
+from chevah_compat.tests import setup_package, teardown_package
+
+
+@pytest.fixture(scope='session', autouse=True)
+def setup_package_pytest():
+    """
+    Just wraps pynose package setup to pytest fixtuers.
+
+    Mare sure the name does not start with `pytest` as this is reserved
+    for the pytest framework.
+    """
+    setup_package()
+    yield
+    teardown_package()

--- a/src/chevah_compat/tests/elevated/conftest.py
+++ b/src/chevah_compat/tests/elevated/conftest.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2024 Adi Roiban.
+# See LICENSE for details.
+"""
+Fixtures for pytest run mode.
+"""
+
+import pytest
+
+from chevah_compat.tests.elevated import setup_package, teardown_package
+
+
+@pytest.fixture(scope='session', autouse=True)
+def setup_package_elevated_pytest():
+    """
+    Just wraps pynose elevated package setup to pytest fixtures.
+
+    Mare sure the name does not start with `pytest` as this is reserved
+    for the pytest framework.
+    """
+    setup_package()
+    yield
+    teardown_package()

--- a/src/chevah_compat/tests/normal/testing/test_testcase.py
+++ b/src/chevah_compat/tests/normal/testing/test_testcase.py
@@ -727,37 +727,20 @@ class TestChevahTestCase(ChevahTestCase):
                 'is True.',
             )
 
-    @conditionals.onAdminPrivileges(True)
-    def test_onAdminPrivileges_present(self):
-        """
-        Run test only on machines that execute the tests with administrator
-        privileges.
-        """
-        if self.os_version in ['nt-5.1', 'nt-5.2']:
-            raise AssertionError(
-                'Windows XP and 2003 BS does not run as administrator',
-            )
-
-        if self.ci_name in [self.CI.TRAVIS, self.CI.GITHUB]:
-            raise AssertionError(
-                'Travis and GitHub does not run as administrator',
-            )
-
     @conditionals.onAdminPrivileges(False)
     def test_onAdminPrivileges_missing(self):
         """
-        Run test on build slaves that do not have administrator privileges.
+        Runs test in environments that don't have administrator privileges.
         """
-        if (
-            self.TEST_LANGUAGE == 'FR'
-            or self.os_name
-            or self.ci_name not in [self.CI.BUILDBOT, self.CI.LOCAL]
-        ):
-            # Not available on Windows XP and 2003 and non-buildbot runs.
+        if self.TEST_LANGUAGE == 'FR' or self.ci_name in [
+            self.CI.LOCAL,
+            self.CI.GITHUB,
+        ]:
+            # We expect to local run not to have admin.
             return
 
         raise AssertionError(
-            f'"{self.hostname}" is running with administrator privileges',
+            f'"{self.hostname}" is running with non-administrator privileges',
         )
 
     def test_cleanup_test_segments_file(self):


### PR DESCRIPTION
Scope
=====

Fixes #709

This add support to run compat tests with `pytest`

`pytest` is the current de-facto test framework for Python and we should start using it as it has many nice features. `nose` and `pynose` are dying.


Changes
=======

Update tests for py3

Add pytest configuration.

Run all the `chevah-compat` tests also with `pytest` not only with `pynose`.

As a drive by, update more code for py3 only.


How to try and test the changes
===============================

reviewers: @dumol 

More of a fyi

1.Normal tests
-----------------


You can now run compat test using `pytest` as either

* `./pythia.sh pytest`
* or just run `pytest` directly via `./build-py3/bin/pytest`


2.Elevated tests
-----------------

There are also the "elevated" tests for OS users that are triggered via `sudo ./pythia.sh pytest src/chevah_compat/tests/elevated/`


during test run they will automatically create OS users and will delete the users and group at the end of the test
