### PR TITLE
[#615] Add support to reset current process effective user

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -252,7 +252,7 @@ jobs:
 
     - name: Test elevated
       run: |
-        ./pythia.sh test_ci2 elevated
+        ./pythia.sh test -vs elevated
       env:
         CODECOV_TOKEN: enabled
         USER: runneradmin

--- a/pavement.py
+++ b/pavement.py
@@ -62,7 +62,6 @@ SETUP['repository']['github'] = 'https://github.com/chevah/compat'
 SETUP['test']['package'] = 'chevah_compat.tests'
 SETUP['test']['elevated'] = 'elevated'
 SETUP['test']['nose_options'] = [
-    '--with-randomly',
     # TODO: Add support for extenstions.
     # 690
     # '--with-timer',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chevah-compat"
-version = "1.3.0"
+version = "1.4.0"
 maintainers = [
     { name = "Adi Roiban", email = "adi.roiban@proatria.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,13 +40,13 @@ Homepage = "https://github.com/chevah/compat"
 dev = [
     "ruff ~= 0.7",
     "bunch",
-    "Twisted==24.10.0",
+    "Twisted==24.11.0",
     "incremental",
     "service-identity==24.2.0",
     "pynose == 1.5.3",
     "pytest ~= 8.3",
     "coverage ~= 7.5",
-    "diff_cover == 9.2.0",
+    "diff_cover == 9.2.2",
     "codecov == 2.1.12",
     # Required for showing OpenSSL version in test_ci.
     "pyOpenSSL",

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -1,6 +1,15 @@
 Release notes for chevah.compat
 ===============================
 
+
+1.4.0 - 2024-12-08
+------------------
+
+* ChangeUserException was renamed to ChangeUserError and is now a CompatError.
+* On Unix, CompatUsers.executeAsUser has better support for thread usage.
+* ChevahTestCase.EXCEPTED_DELAYED_CALLS now requires the canonical name
+
+
 1.3.0 - 2024-12-08
 ------------------
 

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -8,6 +8,7 @@ Release notes for chevah.compat
 * ChangeUserException was renamed to ChangeUserError and is now a CompatError.
 * On Unix, CompatUsers.executeAsUser has better support for thread usage.
 * ChevahTestCase.EXCEPTED_DELAYED_CALLS now requires the canonical name
+* ChevahTestCase.dropPrivileges was renamed to setupPrivileges
 
 
 1.3.0 - 2024-12-08

--- a/src/chevah_compat/exceptions.py
+++ b/src/chevah_compat/exceptions.py
@@ -17,12 +17,6 @@ class CompatException(Exception):
         return f'CompatException {self.message}'
 
 
-class ChangeUserException(CompatException):
-    """
-    User could not be impersonated.
-    """
-
-
 class AdjustPrivilegeException(CompatException):
     """
     Could not adjust process privileges.
@@ -43,3 +37,13 @@ class CompatError(Exception):
 
     def __str__(self):
         return self.__repr__()
+
+
+class ChangeUserError(CompatError):
+    """
+    User could not be impersonated.
+    """
+
+    def __init__(self, message):
+        self.event_id = 1006
+        self.message = message

--- a/src/chevah_compat/interfaces.py
+++ b/src/chevah_compat/interfaces.py
@@ -135,6 +135,14 @@ class IHasImpersonatedAvatar(Interface):
         Context manager for impersonating operating system functions.
         """
 
+    def setupResetEffectivePrivileges():
+        """
+        Update any future class instance to reset permissions before
+        checking for impersonation.
+
+        This is a workaround for thread I/O operations that might block.
+        """
+
 
 class IFileSystemAvatar(IHasImpersonatedAvatar):
     """

--- a/src/chevah_compat/nt_filesystem.py
+++ b/src/chevah_compat/nt_filesystem.py
@@ -817,13 +817,13 @@ class NTFilesystem(PosixFilesystemBase):
         path = self.getRealPathFromSegments(segments, include_virtual=False)
         path_encoded = self.getEncodedPath(path)
         try:
-            with self._windowsToOSError(segments), self._impersonateUser():
+            with self._windowsToOSError(segments):
                 if self.isLink(segments):
                     recursive = False
-
-                if recursive:
-                    return self._rmtree(path_encoded)
-                return os.rmdir(path_encoded)
+                with self._impersonateUser():
+                    if recursive:
+                        return self._rmtree(path_encoded)
+                    return os.rmdir(path_encoded)
         except OSError as error:
             # Sometimes windows return a generic EINVAL when path is not a
             # folder.

--- a/src/chevah_compat/nt_users.py
+++ b/src/chevah_compat/nt_users.py
@@ -23,7 +23,7 @@ from zope.interface import implementer
 
 from chevah_compat.compat_users import CompatUsers
 from chevah_compat.constants import CSIDL_FLAG_CREATE, WINDOWS_PRIMARY_GROUP
-from chevah_compat.exceptions import ChangeUserException
+from chevah_compat.exceptions import ChangeUserError
 from chevah_compat.helpers import NoOpContext
 from chevah_compat.interfaces import (
     IFileSystemAvatar,
@@ -104,7 +104,7 @@ class NTUsers(CompatUsers):
             try:
                 with self.executeAsUser(username, token):
                     return self._getHomeFolderPath(token)
-            except ChangeUserException as error:
+            except ChangeUserError as error:
                 self.raiseFailedToGetHomeFolder(username, error.message)
 
         try:
@@ -256,14 +256,15 @@ class NTUsers(CompatUsers):
         """
         Returns a context manager for changing current process privileges
         to `username`
-        Return `ChangeUserException` is there are no permissions for
+
+        Raise `ChangeUserError` is there are no permissions for
         switching to user.
         """
         if username and username == self.getCurrentUserName():
             return NoOpContext()
 
         if token is None:
-            raise ChangeUserException(
+            raise ChangeUserError(
                 'executeAsUser: A valid token is required.',
             )
 

--- a/src/chevah_compat/posix_filesystem.py
+++ b/src/chevah_compat/posix_filesystem.py
@@ -22,7 +22,6 @@ from os import scandir
 from zope.interface import implementer
 
 from chevah_compat.exceptions import (
-    ChangeUserException,
     CompatError,
     CompatException,
 )
@@ -91,16 +90,7 @@ class PosixFilesystemBase:
         if not self._avatar:
             return NoOpContext()
 
-        try:
-            return self._avatar.getImpersonationContext()
-        except ChangeUserException:
-            raise CompatError(
-                1006,
-                _(
-                    f'Could not switch process to local account '
-                    f'"{self._avatar.name}".'
-                ),
-            )
+        return self._avatar.getImpersonationContext()
 
     def _pathSplitRecursive(self, path):
         """

--- a/src/chevah_compat/posix_filesystem.py
+++ b/src/chevah_compat/posix_filesystem.py
@@ -86,6 +86,8 @@ class PosixFilesystemBase:
     def _impersonateUser(self):
         """
         Returns an impersonation context for current user.
+
+        Warning: Make sure that calls to this context manager are not nested.
         """
         if not self._avatar:
             return NoOpContext()

--- a/src/chevah_compat/testing/testcase.py
+++ b/src/chevah_compat/testing/testcase.py
@@ -603,7 +603,7 @@ class TwistedTestCase(TestCase):
         raw_name = str(delayed_call.func)
         raw_name = raw_name.replace('<function ', '')
         raw_name = raw_name.replace('<bound method ', '')
-        return raw_name.split(' ', 1)[0].split('.')[-1]
+        return raw_name.split(' at 0x', 1)[0]
 
     def getDeferredFailure(
         self,

--- a/src/chevah_compat/testing/testcase.py
+++ b/src/chevah_compat/testing/testcase.py
@@ -1208,8 +1208,10 @@ class ChevahTestCase(TwistedTestCase, AssertionMixin):
         cls.cleanTemporaryFolder()
 
     @classmethod
-    def dropPrivileges(cls):
-        """Drop privileges to normal users."""
+    def setupPrivileges(cls):
+        """
+        Drop privileges to non-admin user that is expected to run the tests.
+        """
         if cls._drop_user == '-':
             return
 

--- a/src/chevah_compat/tests/__init__.py
+++ b/src/chevah_compat/tests/__init__.py
@@ -17,7 +17,7 @@ def setup_package():
 
     if drop_user != '-':
         ChevahTestCase.initialize(drop_user=drop_user)
-        ChevahTestCase.dropPrivileges()
+        ChevahTestCase.setupPrivileges()
 
     # Prepare the main testing filesystem.
     mk.fs.setUpTemporaryFolder()

--- a/src/chevah_compat/tests/elevated/test_system_users.py
+++ b/src/chevah_compat/tests/elevated/test_system_users.py
@@ -14,7 +14,7 @@ from chevah_compat import (
 )
 from chevah_compat.administration import os_administration
 from chevah_compat.constants import WINDOWS_PRIMARY_GROUP
-from chevah_compat.exceptions import ChangeUserException, CompatError
+from chevah_compat.exceptions import ChangeUserError, CompatError
 from chevah_compat.helpers import NoOpContext
 from chevah_compat.interfaces import IHasImpersonatedAvatar
 from chevah_compat.testing import (
@@ -433,9 +433,9 @@ class TestSystemUsers(SystemUsersTestCase):
     def test_executeAsUser_unix_user_does_not_exists(self):
         """
         If the user does not exist, executeAsUser will raise
-        ChangeUserException.
+        ChangeUserError.
         """
-        with self.assertRaises(ChangeUserException):
+        with self.assertRaises(ChangeUserError):
             system_users.executeAsUser(username='no-such-user')
 
     def test_getGroupForUser_only_default_user_group_unix(self):

--- a/src/chevah_compat/tests/elevated/testing/test_filesystem.py
+++ b/src/chevah_compat/tests/elevated/testing/test_filesystem.py
@@ -4,7 +4,7 @@
 Tests for testing filesystem
 """
 
-from chevah_compat import DefaultAvatar, system_users
+from chevah_compat import system_users
 from chevah_compat.testing import ChevahTestCase, conditionals, mk
 from chevah_compat.testing import mk as compat_mk
 from chevah_compat.testing.filesystem import LocalTestFilesystem
@@ -42,95 +42,6 @@ class TestElevatedLocalTestFilesystem(ChevahTestCase):
             self.assertEqual(self.user.name, owner)
         finally:
             filesystem.tearDownTemporaryFolder()
-
-    def test_impersonate_nested(self):
-        """
-        The user impersonation works for nested calls.
-
-        Once all nested calls exit, the OS process is reset to the previous
-        user.
-        """
-        initial_user = system_users.getCurrentUserName()
-        filesystem = LocalTestFilesystem(avatar=self.avatar)
-        with filesystem._impersonateUser():
-            self.assertEqual(self.user.name, system_users.getCurrentUserName())
-            with filesystem._impersonateUser():
-                self.assertEqual(
-                    self.user.name, system_users.getCurrentUserName()
-                )
-
-            # Even though we have exited the context,
-            # we still have the impersonated use as this is a nested call.
-            self.assertEqual(self.user.name, system_users.getCurrentUserName())
-
-        # Once we exit all context, the previous context is set.
-        self.assertEqual(initial_user, system_users.getCurrentUserName())
-
-    def test_nested_no_reset(self):
-        """
-        The user impersonation is not reset when nesting specific user
-        filesystem with the default filesystem
-        """
-        initial_user = system_users.getCurrentUserName()
-        filesystem = LocalTestFilesystem(avatar=self.avatar)
-        default_filesystem = LocalTestFilesystem(avatar=DefaultAvatar())
-
-        with default_filesystem._impersonateUser():
-            # Previous user is kept
-            self.assertEqual(initial_user, system_users.getCurrentUserName())
-
-        with filesystem._impersonateUser():
-            self.assertEqual(self.user.name, system_users.getCurrentUserName())
-
-            with default_filesystem._impersonateUser():
-                # Still uses the nested user.
-                self.assertEqual(
-                    self.user.name, system_users.getCurrentUserName()
-                )
-
-        # Once we exit all context, the previous context is set.
-        self.assertEqual(initial_user, system_users.getCurrentUserName())
-
-    def test_nested_with_reset(self):
-        """
-        The user impersonation can reset when nesting a specific user
-        filesystem with the default filesystem.
-        """
-        initial_user = system_users.getCurrentUserName()
-        filesystem = LocalTestFilesystem(avatar=self.avatar)
-
-        default_filesystem = LocalTestFilesystem(avatar=DefaultAvatar())
-
-        initial_context = DefaultAvatar._NoOpContext
-        DefaultAvatar.setupResetEffectivePrivileges()
-
-        def revert_avatar(initial_context):
-            DefaultAvatar._NoOpContext = initial_context
-
-        self.addCleanup(revert_avatar, initial_context)
-
-        with default_filesystem._impersonateUser():
-            # Previous user is kept
-            self.assertEqual(initial_user, system_users.getCurrentUserName())
-
-        with filesystem._impersonateUser():
-            self.assertEqual(self.user.name, system_users.getCurrentUserName())
-
-            with default_filesystem._impersonateUser():
-                # Reset the user.
-                self.assertEqual(
-                    initial_user, system_users.getCurrentUserName()
-                )
-
-            # Further call to the specific impersonated filesytem will work
-            # and will trigger an impersonation.
-            with filesystem._impersonateUser():
-                self.assertEqual(
-                    self.user.name, system_users.getCurrentUserName()
-                )
-
-        # Once we exit all context, the previous context is set.
-        self.assertEqual(initial_user, system_users.getCurrentUserName())
 
     @conditionals.onOSFamily('posix')
     def test_temporary_folder_unix(self):

--- a/src/chevah_compat/tests/elevated/testing/test_filesystem.py
+++ b/src/chevah_compat/tests/elevated/testing/test_filesystem.py
@@ -4,7 +4,7 @@
 Tests for testing filesystem
 """
 
-from chevah_compat import system_users
+from chevah_compat import DefaultAvatar, system_users
 from chevah_compat.testing import ChevahTestCase, conditionals, mk
 from chevah_compat.testing import mk as compat_mk
 from chevah_compat.testing.filesystem import LocalTestFilesystem
@@ -42,6 +42,95 @@ class TestElevatedLocalTestFilesystem(ChevahTestCase):
             self.assertEqual(self.user.name, owner)
         finally:
             filesystem.tearDownTemporaryFolder()
+
+    def test_impersonate_nested(self):
+        """
+        The user impersonation works for nested calls.
+
+        Once all nested calls exit, the OS process is reset to the previous
+        user.
+        """
+        initial_user = system_users.getCurrentUserName()
+        filesystem = LocalTestFilesystem(avatar=self.avatar)
+        with filesystem._impersonateUser():
+            self.assertEqual(self.user.name, system_users.getCurrentUserName())
+            with filesystem._impersonateUser():
+                self.assertEqual(
+                    self.user.name, system_users.getCurrentUserName()
+                )
+
+            # Even though we have exited the context,
+            # we still have the impersonated use as this is a nested call.
+            self.assertEqual(self.user.name, system_users.getCurrentUserName())
+
+        # Once we exit all context, the previous context is set.
+        self.assertEqual(initial_user, system_users.getCurrentUserName())
+
+    def test_nested_no_reset(self):
+        """
+        The user impersonation is not reset when nesting specific user
+        filesystem with the default filesystem
+        """
+        initial_user = system_users.getCurrentUserName()
+        filesystem = LocalTestFilesystem(avatar=self.avatar)
+        default_filesystem = LocalTestFilesystem(avatar=DefaultAvatar())
+
+        with default_filesystem._impersonateUser():
+            # Previous user is kept
+            self.assertEqual(initial_user, system_users.getCurrentUserName())
+
+        with filesystem._impersonateUser():
+            self.assertEqual(self.user.name, system_users.getCurrentUserName())
+
+            with default_filesystem._impersonateUser():
+                # Still uses the nested user.
+                self.assertEqual(
+                    self.user.name, system_users.getCurrentUserName()
+                )
+
+        # Once we exit all context, the previous context is set.
+        self.assertEqual(initial_user, system_users.getCurrentUserName())
+
+    def test_nested_with_reset(self):
+        """
+        The user impersonation can reset when nesting a specific user
+        filesystem with the default filesystem.
+        """
+        initial_user = system_users.getCurrentUserName()
+        filesystem = LocalTestFilesystem(avatar=self.avatar)
+
+        default_filesystem = LocalTestFilesystem(avatar=DefaultAvatar())
+
+        initial_context = DefaultAvatar._NoOpContext
+        DefaultAvatar.setupResetEffectivePrivileges()
+
+        def revert_avatar(initial_context):
+            DefaultAvatar._NoOpContext = initial_context
+
+        self.addCleanup(revert_avatar, initial_context)
+
+        with default_filesystem._impersonateUser():
+            # Previous user is kept
+            self.assertEqual(initial_user, system_users.getCurrentUserName())
+
+        with filesystem._impersonateUser():
+            self.assertEqual(self.user.name, system_users.getCurrentUserName())
+
+            with default_filesystem._impersonateUser():
+                # Reset the user.
+                self.assertEqual(
+                    initial_user, system_users.getCurrentUserName()
+                )
+
+            # Further call to the specific impersonated filesytem will work
+            # and will trigger an impersonation.
+            with filesystem._impersonateUser():
+                self.assertEqual(
+                    self.user.name, system_users.getCurrentUserName()
+                )
+
+        # Once we exit all context, the previous context is set.
+        self.assertEqual(initial_user, system_users.getCurrentUserName())
 
     @conditionals.onOSFamily('posix')
     def test_temporary_folder_unix(self):

--- a/src/chevah_compat/tests/normal/testing/test_testcase.py
+++ b/src/chevah_compat/tests/normal/testing/test_testcase.py
@@ -338,7 +338,9 @@ class TestTwistedTestCase(ChevahTestCase):
             self._assertReactorIsClean()
 
         self.assertEqual(
-            'Reactor is not clean. delayed calls: much_later',
+            'Reactor is not clean. delayed calls: '
+            'TestTwistedTestCase.test_assertReactorIsClean_excepted_deferred.'
+            '<locals>.much_later',
             context.exception.args[0],
         )
         # Cancel and remove it so that the general test will not fail.
@@ -355,7 +357,11 @@ class TestTwistedTestCase(ChevahTestCase):
             This is here to have a name.
             """
 
-        self.EXCEPTED_DELAYED_CALLS = ['much_later']
+        self.EXCEPTED_DELAYED_CALLS = [
+            'TestTwistedTestCase.'
+            'test_assertReactorIsClean_excepted_delayed_calls.'
+            '<locals>.much_later'
+        ]
 
         delayed_call = reactor.callLater(10, much_later)
 

--- a/src/chevah_compat/unix_capabilities.py
+++ b/src/chevah_compat/unix_capabilities.py
@@ -7,7 +7,7 @@ Provides information about capabilities for a process on Unix.
 from zope.interface import implementer
 
 from chevah_compat.capabilities import BaseProcessCapabilities
-from chevah_compat.exceptions import ChangeUserException
+from chevah_compat.exceptions import ChangeUserError
 from chevah_compat.helpers import _
 from chevah_compat.interfaces import IProcessCapabilities
 from chevah_compat.unix_users import _ExecuteAsUser
@@ -26,7 +26,7 @@ class UnixProcessCapabilities(BaseProcessCapabilities):
         try:
             with _ExecuteAsUser(euid=0, egid=0):
                 return True
-        except ChangeUserException:
+        except ChangeUserError:
             return False
 
     @property

--- a/src/chevah_compat/unix_filesystem.py
+++ b/src/chevah_compat/unix_filesystem.py
@@ -208,10 +208,12 @@ class UnixFilesystem(PosixFilesystemBase):
             raise CompatError(1009, 'Deleting Unix root folder is not allowed.')
 
         path_encoded = self.getEncodedPath(path)
+
+        if self.isLink(segments):
+            self.deleteFile(segments)
+            return None
+
         with self._impersonateUser():
-            if self.isLink(segments):
-                self.deleteFile(segments)
-                return None
             if recursive:
                 return self._rmtree(path_encoded)
             return os.rmdir(path_encoded)

--- a/src/chevah_compat/unix_users.py
+++ b/src/chevah_compat/unix_users.py
@@ -27,6 +27,9 @@ from chevah_compat.interfaces import (
     IOSUsers,
 )
 
+_GLOBAL_EUID = os.geteuid()
+_GLOBAL_EGID = os.getegid()
+
 
 def _get_euid_and_egid(username):
     """
@@ -61,6 +64,7 @@ def _change_effective_privileges(username=None, euid=None, egid=None):
 
     uid, gid = os.geteuid(), os.getegid()
     if uid == euid and gid == egid:
+        # We are already under the requested user.
         return
 
     try:
@@ -111,6 +115,13 @@ class UnixUsers(CompatUsers):
     # they are active.
     # `NP` is Centrify way of saying `*NP*`.
     _NOT_HERE = ('x', 'NP', '*NP*', '*')
+
+    def getCurrentUserName(self):
+        """
+        Return the name of the account under which the current
+        process is executed.
+        """
+        return pwd.getpwuid(os.geteuid()).pw_name
 
     def getHomeFolder(self, username, token=None):
         """Get home folder for local (or NIS) user."""
@@ -229,7 +240,13 @@ class UnixUsers(CompatUsers):
         Raise `ChangeUserError` is there are no permissions for
         switching to user.
         """
+        global _GLOBAL_EUID, _GLOBAL_EGID
+
         _change_effective_privileges(username)
+
+        # Record the new default user.
+        _GLOBAL_EUID = os.geteuid()
+        _GLOBAL_EGID = os.getegid()
 
     def executeAsUser(self, username, token=None):
         """
@@ -397,7 +414,9 @@ class UnixUsers(CompatUsers):
 
 
 class _ExecuteAsUser:
-    """Context manager for running under a different user."""
+    """
+    Context manager for running under a different user.
+    """
 
     def __init__(self, username=None, euid=0, egid=0):
         """Initialize the context manager."""
@@ -410,20 +429,44 @@ class _ExecuteAsUser:
             egid = pwnam.pw_gid
         self.euid = euid
         self.egid = egid
-        self.initial_euid = os.geteuid()
-        self.initial_egid = os.getegid()
+        self._initial_euid = os.geteuid()
+        self._initial_egid = os.getegid()
 
     def __enter__(self):
-        """Change process effective user."""
+        """
+        Change process effective user.
+        """
         _change_effective_privileges(euid=self.euid, egid=self.egid)
         return self
 
     def __exit__(self, exc_type, exc_value, tb):
-        """Reverting previous effective ID."""
+        """
+        Reverting to the default effective ID.
+        """
         _change_effective_privileges(
-            euid=self.initial_euid,
-            egid=self.initial_egid,
+            euid=self._initial_euid,
+            egid=self._initial_egid,
         )
+        return False
+
+
+class ResetEffectivePrivilegesUnixContext:
+    """
+    A context manager that reset the effecit user.
+    """
+
+    def __enter__(self):
+        """
+        See class docstring.
+        """
+        _change_effective_privileges(
+            euid=_GLOBAL_EUID,
+            egid=_GLOBAL_EGID,
+        )
+        return self
+
+    def __exit__(self, exc_type, exc_value, tb):
+        """Just propagate errors."""
         return False
 
 
@@ -432,9 +475,15 @@ class UnixHasImpersonatedAvatar:
     _euid = None
     _egid = None
 
+    _NoOpContext = NoOpContext
+
     def __init__(self):
         self._euid = None
         self._egid = None
+
+    @classmethod
+    def setupResetEffectivePrivileges(cls):
+        cls._NoOpContext = ResetEffectivePrivilegesUnixContext
 
     @property
     def use_impersonation(self):
@@ -448,7 +497,7 @@ class UnixHasImpersonatedAvatar:
         See: :class:`IFileSystemAvatar`
         """
         if not self.use_impersonation:
-            return NoOpContext()
+            return self._NoOpContext()
 
         # Create cached values if not initialized.
         if not (self._euid and self._egid):


### PR DESCRIPTION
Scope
=====

Fixes #615

This is a hack to somehow fix a threading issue that we have in chevah/server

Our whole code is not designed for running threads with separate user context.

This is a fix only for Linux... but out customer that use this only use Linux.


Changes
=======

Add support for run in non-blocking mode... so if an I/O operation is blocked, the whole process is not.

Add some unit tests


How to try and test the changes
===============================

reviewers: @dumol 

More of a FYI

The actual testing should be done in chevah/server

The main tests are at https://github.com/chevah/server/pull/6975