### PR TITLE
#718 Allow PAM auth as non root user

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -14,7 +14,7 @@ coverage:
     project:
       default:
         target: auto
-        threshold: 0.05%
+        threshold: 0.1%
 
 comment:
   layout: "header, diff, files, components"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chevah-compat"
-version = "1.4.0"
+version = "1.5.0"
 maintainers = [
     { name = "Adi Roiban", email = "adi.roiban@proatria.com" },
 ]
@@ -43,10 +43,10 @@ dev = [
     "Twisted==24.11.0",
     "incremental",
     "service-identity==24.2.0",
-    "pynose == 1.5.3",
+    "pynose == 1.5.4",
     "pytest ~= 8.3",
     "coverage ~= 7.5",
-    "diff_cover == 9.2.2",
+    "diff_cover == 9.2.3",
     "codecov == 2.1.12",
     # Required for showing OpenSSL version in test_ci.
     "pyOpenSSL",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dev = [
     "service-identity==24.2.0",
     "pynose == 1.5.4",
     "pytest ~= 8.3",
-    "coverage ~= 7.5",
+    "coverage ~= 7.6",
     "diff_cover == 9.2.4",
     "codecov == 2.1.12",
     # Required for showing OpenSSL version in test_ci.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dev = [
     "pynose == 1.5.4",
     "pytest ~= 8.3",
     "coverage ~= 7.5",
-    "diff_cover == 9.2.3",
+    "diff_cover == 9.2.4",
     "codecov == 2.1.12",
     # Required for showing OpenSSL version in test_ci.
     "pyOpenSSL",

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -5,7 +5,7 @@ Release notes for chevah.compat
 1.5.0 - 2025-03-19
 ------------------
 
-* Authenticate OS users with only PAM and without root requirement.
+* Add API to authenticate OS users with only PAM and without root requirement.
 
 
 1.4.0 - 2024-12-08

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,12 @@ Release notes for chevah.compat
 ===============================
 
 
+1.5.0 - 2025-03-19
+------------------
+
+* Authenticate OS users with only PAM and without root requirement.
+
+
 1.4.0 - 2024-12-08
 ------------------
 

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -6,7 +6,7 @@ Release notes for chevah.compat
 ------------------
 
 * Add API to authenticate OS users with only PAM and without root requirement.
-
+* Remove `conditionals.onOSVersion` helper.
 
 1.4.0 - 2024-12-08
 ------------------

--- a/src/chevah_compat/testing/conditionals.py
+++ b/src/chevah_compat/testing/conditionals.py
@@ -88,20 +88,6 @@ def onOSName(name):
     return skipOnCondition(check_os_name, f'OS name "{name}" not available.')
 
 
-def onOSVersion(versions):
-    """
-    Run test only if current os vesrsion or is in one from `versions` list.
-    """
-
-    def check_os_version():
-        return process_capabilities.os_version not in versions
-
-    return skipOnCondition(
-        check_os_version,
-        f'OS version "{versions}" not available.',
-    )
-
-
 def onCapability(name, value):
     """
     Run test only if capability with `name` equals `value`.

--- a/src/chevah_compat/tests/normal/test_system_users.py
+++ b/src/chevah_compat/tests/normal/test_system_users.py
@@ -134,7 +134,8 @@ class TestSystemUsers(CompatTestCase):
         """
         with self.assertRaises(CompatError) as context:
             system_users.pamWithUsernameAndPassword(
-            'no-such-user', 'password-ignored')
+                'no-such-user', 'password-ignored'
+            )
 
         self.assertEqual(1006, context.exception.event_id)
 
@@ -147,7 +148,8 @@ class TestSystemUsers(CompatTestCase):
             raise self.skipTest('Alpine has no PAM')
 
         result = system_users.pamOnlyWithUsernameAndPassword(
-            'no-such-user', 'password-ignored')
+            'no-such-user', 'password-ignored'
+        )
 
         self.assertIsFalse(result)
 
@@ -160,7 +162,8 @@ class TestSystemUsers(CompatTestCase):
             raise self.skipTest('Alpine has no PAM')
 
         result = system_users.pamOnlyWithUsernameAndPassword(
-            'root', 'password-bad')
+            'root', 'password-bad'
+        )
 
         self.assertIsFalse(result)
 
@@ -175,18 +178,23 @@ class TestSystemUsers(CompatTestCase):
 
         current_user = os.environ.get('USER')
         result = system_users.pamOnlyWithUsernameAndPassword(
-            current_user, 'password-bad')
+            current_user, 'password-bad'
+        )
 
         self.assertIsFalse(result)
 
-    @conditionals.onOSVersion('alpine-3')
+    @conditionals.onOSName('linux')
     def test_pamOnlyWithUsernameAndPassword_no_pam(self):
         """
         Raises an error if PAM is not available on the OS.
         """
+        if not self.os_version.startswith('alpine-'):
+            raise self.skipTest('Test only for Alpine.')
+
         with self.assertRaises(CompatError) as context:
             system_users.pamWithUsernameAndPassword(
-                'no-such-user', 'password-ignored')
+                'no-such-user', 'password-ignored'
+            )
 
         self.assertEqual(1006, context.exception.event_id)
 

--- a/src/chevah_compat/tests/normal/test_system_users.py
+++ b/src/chevah_compat/tests/normal/test_system_users.py
@@ -143,13 +143,16 @@ class TestSystemUsers(CompatTestCase):
         """
         Return false when user is not found.
         """
+        if self.os_version.startswith('alpine-'):
+            raise self.skipTest('Alpine has no PAM')
+
         result = system_users.pamOnlyWithUsernameAndPassword(
             'no-such-user', 'password-ignored')
 
         self.assertIsFalse(result)
 
     @conditionals.onOSName('linux')
-    def test_pamOnlyWithUsernameAndPassword_bad_password(self):
+    def test_pamOnlyWithUsernameAndPassword_root_bad_password(self):
         """
         Return false when trying to authenticate the root.
         """
@@ -175,6 +178,17 @@ class TestSystemUsers(CompatTestCase):
             current_user, 'password-bad')
 
         self.assertIsFalse(result)
+
+    @conditionals.onOSVersion('alpine-3')
+    def test_pamOnlyWithUsernameAndPassword_no_pam(self):
+        """
+        Raises an error if PAM is not available on the OS.
+        """
+        with self.assertRaises(CompatError) as context:
+            system_users.pamWithUsernameAndPassword(
+                'no-such-user', 'password-ignored')
+
+        self.assertEqual(1006, context.exception.event_id)
 
 
 class TestDefaultAvatar(CompatTestCase):

--- a/src/chevah_compat/tests/normal/test_system_users.py
+++ b/src/chevah_compat/tests/normal/test_system_users.py
@@ -127,7 +127,7 @@ class TestSystemUsers(CompatTestCase):
 
         self.assertTrue(HAS_SHADOW_SUPPORT)
 
-    @conditionals.onOSFamily('posix')
+    @conditionals.onOSName('linux')
     def test_pamWithUsernameAndPassword_no_such_user(self):
         """
         Raise an error for any auth request.
@@ -138,7 +138,7 @@ class TestSystemUsers(CompatTestCase):
 
         self.assertEqual(1006, context.exception.event_id)
 
-    @conditionals.onOSFamily('posix')
+    @conditionals.onOSName('linux')
     def test_pamOnlyWithUsernameAndPassword_no_such_user(self):
         """
         Return false when user is not found.
@@ -148,22 +148,28 @@ class TestSystemUsers(CompatTestCase):
 
         self.assertIsFalse(result)
 
-    @conditionals.onOSFamily('posix')
+    @conditionals.onOSName('linux')
     def test_pamOnlyWithUsernameAndPassword_bad_password(self):
         """
         Return false when trying to authenticate the root.
         """
+        if self.os_version.startswith('alpine-'):
+            raise self.skipTest('Alpine has no PAM')
+
         result = system_users.pamOnlyWithUsernameAndPassword(
             'root', 'password-bad')
 
         self.assertIsFalse(result)
 
-    @conditionals.onOSFamily('posix')
+    @conditionals.onOSName('linux')
     def test_pamOnlyWithUsernameAndPassword_bad_password(self):
         """
         Return false when trying to authenticate the current user with
         a bad password.
         """
+        if self.os_version.startswith('alpine-'):
+            raise self.skipTest('Alpine has no PAM')
+
         current_user = os.environ.get('USER')
         result = system_users.pamOnlyWithUsernameAndPassword(
             current_user, 'password-bad')

--- a/src/chevah_compat/tests/normal/test_system_users.py
+++ b/src/chevah_compat/tests/normal/test_system_users.py
@@ -176,6 +176,11 @@ class TestSystemUsers(CompatTestCase):
         if self.os_version.startswith('alpine-'):
             raise self.skipTest('Alpine has no PAM')
 
+        if self.ci_name == self.CI.GITHUB and self.os_version == 'ubuntu-24':
+            # I don't know why on GHA and Ubuntu 24 any password is accepted
+            # by PAM for the curent user.
+            raise self.skipTest('GitHub Action user accepts any password.')
+
         current_user = os.environ.get('USER')
         result = system_users.pamOnlyWithUsernameAndPassword(
             current_user, 'password-bad'

--- a/src/chevah_compat/unix_users.py
+++ b/src/chevah_compat/unix_users.py
@@ -245,7 +245,10 @@ class UnixUsers(CompatUsers):
         Returns True if credentials are accepted, False otherwise.
         """
         from pam import authenticate as pam_authenticate
-        checked = pam_authenticate(username, password, service)
+        try:
+            checked = pam_authenticate(username, password, service)
+        except AttributeError:
+            raise ChangeUserError('PAM is not available.')
 
         if checked is True:
             return True

--- a/src/chevah_compat/unix_users.py
+++ b/src/chevah_compat/unix_users.py
@@ -232,7 +232,8 @@ class UnixUsers(CompatUsers):
         # Credentials are always rejected.
         return False
 
-    def pamOnlyWithUsernameAndPassword(self, username, password, service='login'):
+    def pamOnlyWithUsernameAndPassword(
+            self, username, password, service='login'):
         """
         Check username and password using only PAM and using the current
         service user.

--- a/src/chevah_compat/unix_users.py
+++ b/src/chevah_compat/unix_users.py
@@ -234,6 +234,26 @@ class UnixUsers(CompatUsers):
         # Credentials are always rejected.
         return False
 
+    def pamOnlyWithUsernameAndPassword(self, username, password, service='login'):
+        """
+        Check username and password using only PAM and using the current
+        service user.
+
+        No root is required.
+
+        Returns True if credentials are accepted, False otherwise.
+        """
+        from pam import authenticate as pam_authenticate
+        checked = pam_authenticate(username, password, service)
+
+        if checked is True:
+            return True
+
+        # For PAM account we don't know if this is a failure due to
+        # a bad credentials or non existent credentials.
+        # Credentials are always rejected.
+        return False
+
     def dropPrivileges(self, username):
         """Change process privileges to `username`.
 

--- a/src/chevah_compat/unix_users.py
+++ b/src/chevah_compat/unix_users.py
@@ -233,7 +233,8 @@ class UnixUsers(CompatUsers):
         return False
 
     def pamOnlyWithUsernameAndPassword(
-            self, username, password, service='login'):
+        self, username, password, service='login'
+    ):
         """
         Check username and password using only PAM and using the current
         service user.
@@ -246,6 +247,7 @@ class UnixUsers(CompatUsers):
         Returns True if credentials are accepted, False otherwise.
         """
         from pam import authenticate as pam_authenticate
+
         try:
             checked = pam_authenticate(username, password, service)
         except AttributeError:

--- a/src/chevah_compat/unix_users.py
+++ b/src/chevah_compat/unix_users.py
@@ -219,11 +219,9 @@ class UnixUsers(CompatUsers):
             return False
 
         with self._executeAsAdministrator():
-            # TODO: Look to do PAM without root context.
-            # 3059
-            # PAM can be used without admin right but I have no idea why
-            # it fails with errors like:
-            # audit_log_acct_message() failed: Operation not permitted.
+            # Some PAM modules and some PAM setups might not need root.
+            # Most of the time, PAM is configured as a proxy for /etc/shadow
+            # and in this case root is required.
             checked = pam_authenticate(username, password, service)
 
         if checked is True:
@@ -240,6 +238,9 @@ class UnixUsers(CompatUsers):
         service user.
 
         No root is required.
+
+        Event if users and passwords are valid, this might fail, depending
+        on PAM configuration.
 
         Returns True if credentials are accepted, False otherwise.
         """


### PR DESCRIPTION
Scope
=====

Fixes #718

This adds support to authenticate Linux OS users using only PAM as non root.

This is somehow similar to what we get in WIndows.

I am user `chevah` , as long as I get username and password for user `JohnDoe` I can use PAM, as a non root user, to check whether the credentials are valid.


Changes
=======

Add a separeate non-root PAM only method.

The old root PAM method was kept for backward compatibility

Automated tests are complicated... when we autoamtically create OS test users we run as root.

This functionality assumes that you are not root... but if we are not root, we can't automatically add OS users... so we can't do automated tests

I wrote some tests to make sure we don't get unexpected errors for wrong password

--------

onOSVersion was removed as the low-level API no longer support is.
os_version was moved to be available only during testing.
We might add it back later.

----------

As a drive-by change I have updated some deps


How to try and test the changes
===============================

reviewers: @dumol 

More of a FYI

There will be some manual tests in chevah/server

This is also hard to test.

Most PAM setup, will only allow validating the password of the current user... for example to help with screensavers.
If you need to authenticate other users, you will need root access.

THis is unfortunate... but this is Linux.


Some PAM setup, might have a LDAP or SSSD module that does the authentication over the network and root is not required.

The code from here is to provide the low-level API.

We will see in chevah/server how to implement this in an application